### PR TITLE
Add dynamic network rule management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,15 @@ The repo is a **scaffolding tool** — it contains only the CLI and templates. U
 
 ```
 snowclaw/                    # CLI repo (installed via pipx)
-  snowclaw.py               # Python CLI — setup, dev, build, deploy, update commands
+  snowclaw/                  # Python package
+    cli.py                   # Entry point and argument parser
+    commands.py              # CLI command implementations
+    config.py                # Config file writers (.env, openclaw.json, connections.toml)
+    network.py               # Network rule management (detect, diff, apply, persist)
+    scaffold.py              # User file scaffolding and build context assembly
+    snowflake.py             # Snowflake object creation via REST API
+    stage.py                 # SPCS stage push/pull
+    utils.py                 # Naming, project discovery, REST API, shared utilities
   pyproject.toml             # Python packaging (hatchling), entry point, deps
   install.sh                 # Curl-able installer — clones repo, pipx install -e
   templates/                 # Used at build time, NOT copied to user projects
@@ -34,6 +42,7 @@ snowclaw/                    # CLI repo (installed via pipx)
 my-openclaw/                 # User's project directory
   .snowclaw/                 # Marker directory
     config.json              # Marker (JSON: version, timestamp, prefix, openclaw_version)
+    network-rules.json       # Approved network rules for external access
     build/                   # Generated at dev/deploy time, gitignored
   .env                       # Generated — actual secrets (gitignored)
   .gitignore                 # Copied from templates/
@@ -60,22 +69,30 @@ my-openclaw/                 # User's project directory
   spcs/
     service.yaml             # From CLI templates, prefix-substituted
     image-repo.sql           # From CLI templates, prefix-substituted
+    network-rules.sql        # Generated from .snowclaw/network-rules.json
 ```
 
-## CLI (`snowclaw.py`)
+## CLI
 
-Single-file Python CLI using argparse + Rich + InquirerPy. Installed via `pipx install -e` from the cloned repo (not published to PyPI — the CLI needs the repo files).
+Multi-module Python CLI using argparse + Rich + InquirerPy. Installed via `pipx install -e` from the cloned repo (not published to PyPI — the CLI needs the repo files).
 
 ### Commands
 
 | Command | Description |
 |---------|-------------|
-| `snowclaw setup` | Scaffolds user files (skills/, .gitignore, workspace/), collects credentials, writes .env + openclaw.json + connections.toml, optionally creates Snowflake objects via REST API |
+| `snowclaw setup` | Scaffolds user files (skills/, .gitignore, workspace/), collects credentials, writes .env + openclaw.json + connections.toml, detects and prompts for network rules, optionally creates Snowflake objects via REST API |
 | `snowclaw setup --force` | Same as setup, but overwrites existing template files |
 | `snowclaw dev` | Assembles build context into `.snowclaw/build/`, runs `docker compose up --build` |
 | `snowclaw build` | Assembles build context, runs `docker build` (no deploy) |
-| `snowclaw deploy` | Assembles build context, docker build/push to Snowflake registry, creates/updates SPCS service via REST API |
+| `snowclaw deploy` | Checks network rules for changes (prompts if new rules needed), assembles build context, docker build/push to Snowflake registry, creates/updates SPCS service via REST API |
 | `snowclaw update` | Updates `openclaw_version` in `.snowclaw/config.json` marker, optionally redeploys |
+| `snowclaw pull` | Pull skills and/or workspace from SPCS stage (`--workspace-only`, `--skills-only`) |
+| `snowclaw push` | Push skills and/or workspace to SPCS stage (`--workspace-only`, `--skills-only`) |
+| `snowclaw network list` | Show current approved network rules |
+| `snowclaw network add <host[:port]>` | Add a network rule (`--reason` flag optional), prompts to apply to Snowflake |
+| `snowclaw network remove <host[:port]>` | Remove a network rule, prompts to apply to Snowflake |
+| `snowclaw network detect` | Auto-detect required rules from openclaw.json, show diff, optionally save and apply |
+| `snowclaw network apply` | Push all saved rules to Snowflake (CREATE OR REPLACE network rule + external access integration) |
 | `snowclaw` (bare) | Defaults to `setup` |
 
 ### Installation
@@ -108,9 +125,9 @@ curl -fsSL https://raw.githubusercontent.com/OWNER/snowclaw/main/install.sh | ba
 - Database: `snowclaw_db`, Schema: `snowclaw_db.snowclaw_schema`
 - Image repository: `snowclaw_repo`
 - Internal stage: `snowclaw_state_stage` (backs persistent volume)
-- Secret: `snowclaw_secrets` (API keys as JSON)
-- Network rule: `snowclaw_egress_rule` (OpenRouter, Slack, Snowflake APIs)
-- External access integration: `snowclaw_external_access`
+- Secrets: `snowclaw_sf_token`, `snowclaw_openrouter_key`, `snowclaw_slack_bot_token`, `snowclaw_slack_app_token`
+- Network rule: `snowclaw_egress_rule` (dynamic — managed by `snowclaw network`)
+- External access integration: `snowclaw_external_access` (references the network rule)
 - Compute pool: `snowclaw_pool` (CPU_X64_S, 1 node)
 
 ### Service spec (`spcs/service.yaml`)
@@ -128,6 +145,39 @@ curl -fsSL https://raw.githubusercontent.com/OWNER/snowclaw/main/install.sh | ba
 ## Slack Integration (config-only)
 
 Socket mode preferred for SPCS (no public webhook URL needed). Uses `$SLACK_BOT_TOKEN` and `$SLACK_APP_TOKEN`.
+
+## Network Rules (`snowclaw/network.py`)
+
+SPCS blocks all outbound traffic by default. Network rules and external access integrations must be created in Snowflake to allow the container to reach external APIs. SnowClaw manages these dynamically rather than hardcoding them.
+
+### How it works
+
+1. **Auto-detection** (`detect_required_rules()`): Parses `openclaw.json` to find provider `baseUrl` hostnames and enabled channels (Slack). Always includes `*.snowflakecomputing.com:443` for Cortex. Returns a list of `NetworkRule(host, port, reason)`.
+
+2. **Persistence**: Approved rules are saved to `.snowclaw/network-rules.json` (committed to git, not gitignored). Format:
+   ```json
+   {
+     "rules": [
+       {"host": "openrouter.ai", "port": 443, "reason": "openrouter provider"},
+       {"host": "*.snowflakecomputing.com", "port": 443, "reason": "Snowflake Cortex & APIs"}
+     ]
+   }
+   ```
+
+3. **Diff engine** (`diff_rules()`): Compares saved rules against detected/required rules. Returns `(added, removed)` lists.
+
+4. **SQL generation** (`build_network_rule_sql()`): Compiles all rules into two SQL statements:
+   - `CREATE OR REPLACE NETWORK RULE {schema}.{prefix}_egress_rule MODE = EGRESS TYPE = HOST_PORT VALUE_LIST = (...)`
+   - `CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION {prefix}_external_access ALLOWED_NETWORK_RULES = (...) ENABLED = TRUE`
+
+5. **Application** (`apply_network_rules()`): Executes the SQL via Snowflake REST API. Updating the network rule is sufficient — the service's external access integration references it, so changes take effect without redeploying the service.
+
+### Integration points
+
+- **`cmd_setup()`**: After writing config files, detects required rules, prompts for approval, saves to `network-rules.json`, applies to Snowflake alongside other objects.
+- **`cmd_deploy()`**: Before building, diffs saved rules vs. detected. If changes found, shows diff and prompts for approval. Applies before proceeding with deploy.
+- **`assemble_build_context()`**: Generates `spcs/network-rules.sql` in the build context from saved rules (for reference/manual use).
+- **`cmd_network()`**: Manual management — `list`, `add`, `remove`, `detect`, `apply` subcommands. `add` and `remove` prompt to apply immediately.
 
 ## Plugins (stubs — not yet implemented)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Run [OpenClaw](https://github.com/openclaw/openclaw) on [Snowflake Container Ser
 
 ## Features
 
-- **One-command setup** — Interactive wizard collects credentials, generates config, and optionally provisions all Snowflake objects (database, image repo, compute pool, secrets, network rules) via REST API. No snowsql required.
+- **One-command setup** — Interactive wizard collects credentials, generates config, and optionally provisions all Snowflake objects (database, image repo, compute pool, secrets) via REST API. No snowsql required.
+- **Dynamic network rules** — Auto-detects required external hosts from your config (providers, Slack) and prompts for approval before creating Snowflake network rules. Add custom hosts on the fly with `snowclaw network add`.
 - **Snowflake Cortex LLMs** — Pre-configured as a provider. Models run inside Snowflake with no data leaving your account.
 - **OpenRouter support** — Optional access to 200+ models (Claude, GPT-4, Gemini, Llama, etc.) through a single API key.
 - **Slack integration** — Socket mode out of the box — no public webhook URL needed, which is ideal for SPCS.
@@ -63,8 +64,15 @@ Once complete, open `http://localhost:18789` to access the OpenClaw UI.
 | `snowclaw update` | Update the OpenClaw base image version |
 | `snowclaw pull` | Pull skills and workspace from SPCS stage to local |
 | `snowclaw push` | Push local skills and workspace to SPCS stage |
+| `snowclaw network list` | Show current approved network rules |
+| `snowclaw network add <host>` | Add a network rule (prompts to apply to Snowflake) |
+| `snowclaw network remove <host>` | Remove a network rule |
+| `snowclaw network detect` | Auto-detect required rules from project config |
+| `snowclaw network apply` | Push current rules to Snowflake |
 
 `snowclaw pull` and `snowclaw push` accept `--workspace-only` or `--skills-only` to sync selectively.
+
+`snowclaw network add` accepts `host` or `host:port` (default port 443) and an optional `--reason` flag.
 
 ## Project Structure
 
@@ -74,6 +82,7 @@ After running `snowclaw setup`, your project directory looks like this:
 my-openclaw/
   .snowclaw/              # Project marker and build artifacts
     config.json           # Project metadata (version, prefix, etc.)
+    network-rules.json    # Approved network rules for external access
   .env                    # Secrets — gitignored
   .gitignore
   openclaw.json           # OpenClaw configuration (providers, channels, agents)
@@ -90,6 +99,35 @@ Edit `openclaw.json` to add agents, change model routing, or configure channels.
 **Snowflake Cortex** is always enabled. It uses your Snowflake account credentials to call Cortex LLMs — your data stays within Snowflake.
 
 **OpenRouter** is optional. If you provide an API key during setup, it's configured as an OpenAI-compatible provider at `https://openrouter.ai/api/v1`, giving you access to models from Anthropic, OpenAI, Google, Meta, and others.
+
+## Network Rules
+
+Snowflake Container Services blocks all outbound traffic by default. SnowClaw manages network rules dynamically so your service can reach external APIs.
+
+**During setup**, the CLI auto-detects which hosts are required based on your config (e.g., `openrouter.ai:443` if OpenRouter is enabled, Slack WebSocket endpoints if Slack is enabled, `*.snowflakecomputing.com:443` for Cortex) and prompts you to approve them before creating the Snowflake objects.
+
+**During deploy**, the CLI re-checks your config against saved rules and prompts for approval if anything changed (e.g., you added a new provider).
+
+**Manual management** is available for hosts the CLI can't auto-detect:
+
+```bash
+# Add a custom API endpoint
+snowclaw network add api.example.com --reason "Custom API"
+
+# Add with a non-standard port
+snowclaw network add db.example.com:5432 --reason "External database"
+
+# View current rules
+snowclaw network list
+
+# Remove a rule
+snowclaw network remove api.example.com
+
+# Push current rules to Snowflake
+snowclaw network apply
+```
+
+Rules are saved in `.snowclaw/network-rules.json` (committed to git) and compiled into a single Snowflake `NETWORK RULE` + `EXTERNAL ACCESS INTEGRATION` when applied.
 
 ## Deploying to SPCS
 

--- a/snowclaw/cli.py
+++ b/snowclaw/cli.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import argparse
 
 from snowclaw import __version__
-from snowclaw.commands import cmd_build, cmd_deploy, cmd_dev, cmd_pull, cmd_push, cmd_setup, cmd_update
+from snowclaw.commands import (
+    cmd_build,
+    cmd_deploy,
+    cmd_dev,
+    cmd_network,
+    cmd_pull,
+    cmd_push,
+    cmd_setup,
+    cmd_update,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -34,6 +43,24 @@ def build_parser() -> argparse.ArgumentParser:
     push_group.add_argument("--workspace-only", action="store_true", help="Only push workspace/")
     push_group.add_argument("--skills-only", action="store_true", help="Only push skills/")
 
+    # --- snowclaw network ---
+    net_parser = sub.add_parser(
+        "network", help="Manage network rules for SPCS external access"
+    )
+    net_sub = net_parser.add_subparsers(dest="network_command")
+
+    net_sub.add_parser("list", help="List current approved network rules")
+
+    add_parser = net_sub.add_parser("add", help="Add a network rule")
+    add_parser.add_argument("host", help="Host or host:port (default port 443)")
+    add_parser.add_argument("--reason", "-r", default="", help="Reason for this rule")
+
+    remove_parser = net_sub.add_parser("remove", help="Remove a network rule")
+    remove_parser.add_argument("host", help="Host or host:port to remove")
+
+    net_sub.add_parser("apply", help="Apply current rules to Snowflake")
+    net_sub.add_parser("detect", help="Auto-detect required rules from project config")
+
     return parser
 
 
@@ -49,6 +76,7 @@ def main():
         "update": cmd_update,
         "pull": cmd_pull,
         "push": cmd_push,
+        "network": cmd_network,
     }
 
     handler = commands.get(args.command or "setup")

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -15,6 +15,17 @@ from rich.panel import Panel
 
 from snowclaw import __version__
 from snowclaw.config import write_connections_toml, write_dotenv, write_openclaw_config
+from snowclaw.network import (
+    NetworkRule,
+    apply_network_rules,
+    detect_required_rules,
+    diff_rules,
+    format_rules_table,
+    load_network_rules,
+    parse_host_port,
+    print_diff,
+    save_network_rules,
+)
 from snowclaw.scaffold import assemble_build_context, scaffold_user_files
 from snowclaw.snowflake import run_snowflake_setup
 from snowclaw.utils import (
@@ -24,6 +35,7 @@ from snowclaw.utils import (
     load_snowflake_context,
     read_marker,
     render_banner,
+    sf_names,
     snowflake_rest_execute,
     write_marker,
 )
@@ -160,12 +172,45 @@ def cmd_setup(args: argparse.Namespace):
     write_openclaw_config(root, settings)
     write_connections_toml(root, settings)
 
+    # --- Detect and approve network rules ---
+    console.print()
+    console.print("[bold]Detecting required network rules...[/bold]")
+    detected = detect_required_rules(root)
+    names = sf_names(settings["database"], settings["schema"])
+
+    if detected:
+        console.print()
+        console.print("[bold]The following network rules are required for external access:[/bold]")
+        for r in detected:
+            console.print(
+                f"  [green]+[/green] [cyan]{r.host_port}[/cyan]  [dim]{r.reason}[/dim]"
+            )
+        console.print()
+        approve_rules = inquirer.confirm(
+            message="Approve these network rules?",
+            default=True,
+        ).execute()
+        if approve_rules:
+            save_network_rules(root, detected)
+            console.print("[green]Network rules saved.[/green]")
+        else:
+            console.print(
+                "[yellow]Network rules not approved. External access will be unavailable.[/yellow]"
+            )
+            console.print(
+                "[dim]You can add rules later with [cyan]snowclaw network add <host>[/cyan][/dim]"
+            )
+    else:
+        console.print("  [dim]No external network rules detected.[/dim]")
+
     # --- Optionally create Snowflake objects ---
     console.print()
     create_objects = inquirer.confirm(
         message="Create Snowflake objects now? (database, schema, compute pool, etc.)",
         default=True,
     ).execute()
+
+    approved_rules = load_network_rules(root)
 
     if create_objects:
         console.print()
@@ -175,6 +220,13 @@ def cmd_setup(args: argparse.Namespace):
             console.print("[green]Snowflake objects created successfully.[/green]")
         except Exception:
             console.print("[yellow]Some objects may not have been created. You can retry or create them manually.[/yellow]")
+
+        # Apply approved network rules
+        if approved_rules:
+            console.print()
+            apply_network_rules(
+                settings["account"], settings["pat"], names, approved_rules
+            )
 
     # --- Summary ---
     console.print()
@@ -265,6 +317,44 @@ def cmd_deploy(args: argparse.Namespace):
     repo = names["repo"]
     registry_host = f"{registry_account}.registry.snowflakecomputing.com"
     image_repo = f"{registry_host}/{db}/{schema_name}/{repo}"
+
+    # Check network rules before deploying
+    console.print("[bold]Checking network rules...[/bold]")
+    current_rules = load_network_rules(root)
+    detected_rules = detect_required_rules(root)
+    added, removed = diff_rules(current_rules, detected_rules)
+
+    if added or removed:
+        console.print()
+        console.print("[bold]Network rule changes detected:[/bold]")
+        print_diff(added, removed)
+        console.print()
+        approve = inquirer.confirm(
+            message="Approve these network rule changes?",
+            default=True,
+        ).execute()
+        if approve:
+            # Merge changes
+            removed_set = {(r.host, r.port) for r in removed}
+            merged = [r for r in current_rules if (r.host, r.port) not in removed_set]
+            existing_set = {(r.host, r.port) for r in merged}
+            for r in added:
+                if (r.host, r.port) not in existing_set:
+                    merged.append(r)
+            save_network_rules(root, merged)
+            apply_network_rules(account, token, names, merged)
+            console.print()
+        else:
+            console.print("[dim]Keeping existing network rules.[/dim]")
+            if current_rules:
+                console.print()
+    elif current_rules:
+        console.print(f"  [green]✓[/green] {len(current_rules)} rules up to date")
+        console.print()
+    else:
+        console.print("  [yellow]No network rules configured.[/yellow]")
+        console.print("  [dim]External access will be unavailable. Use [cyan]snowclaw network add <host>[/cyan] to add rules.[/dim]")
+        console.print()
 
     # Assemble build context
     console.print("[bold]Assembling build context...[/bold]")
@@ -510,3 +600,219 @@ def cmd_push(args: argparse.Namespace):
 
     console.print()
     console.print("[green]Push complete.[/green]")
+
+
+# ---------------------------------------------------------------------------
+# snowclaw network
+# ---------------------------------------------------------------------------
+
+
+def cmd_network(args: argparse.Namespace):
+    """Manage network rules for SPCS external access."""
+    sub = getattr(args, "network_command", None)
+    if not sub:
+        # Default: show current rules
+        _network_list(args)
+        return
+
+    dispatch = {
+        "list": _network_list,
+        "add": _network_add,
+        "remove": _network_remove,
+        "apply": _network_apply,
+        "detect": _network_detect,
+    }
+    handler = dispatch.get(sub)
+    if handler:
+        handler(args)
+
+
+def _network_list(args: argparse.Namespace):
+    """List current approved network rules."""
+    render_banner()
+    root = find_project_root()
+    rules = load_network_rules(root)
+
+    if not rules:
+        console.print("[dim]No network rules configured.[/dim]")
+        console.print(
+            "Run [cyan]snowclaw network detect[/cyan] to auto-detect required rules,"
+        )
+        console.print(
+            "or [cyan]snowclaw network add <host>[/cyan] to add one manually."
+        )
+        return
+
+    console.print(format_rules_table(rules))
+    console.print(f"\n[dim]{len(rules)} rule(s) total[/dim]")
+
+
+def _network_add(args: argparse.Namespace):
+    """Add a network rule."""
+    render_banner()
+    root = find_project_root()
+    rules = load_network_rules(root)
+
+    host_input = getattr(args, "host", None)
+    if not host_input:
+        console.print("[red]Usage: snowclaw network add <host[:port]>[/red]")
+        return
+
+    host, port = parse_host_port(host_input)
+    reason = getattr(args, "reason", "") or ""
+
+    # Check for duplicates
+    for r in rules:
+        if r.host == host and r.port == port:
+            console.print(f"[yellow]Rule already exists:[/yellow] {r.host_port}")
+            return
+
+    if not reason:
+        reason = inquirer.text(
+            message=f"Reason for {host}:{port} (optional):",
+            default="",
+        ).execute().strip()
+
+    new_rule = NetworkRule(host, port, reason)
+    rules.append(new_rule)
+    save_network_rules(root, rules)
+    console.print(f"[green]✓[/green] Added [cyan]{new_rule.host_port}[/cyan]")
+
+    # Offer to apply immediately
+    _offer_apply(root)
+
+
+def _network_remove(args: argparse.Namespace):
+    """Remove a network rule."""
+    render_banner()
+    root = find_project_root()
+    rules = load_network_rules(root)
+
+    host_input = getattr(args, "host", None)
+    if not host_input:
+        console.print("[red]Usage: snowclaw network remove <host[:port]>[/red]")
+        return
+
+    host, port = parse_host_port(host_input)
+    original_count = len(rules)
+    rules = [r for r in rules if not (r.host == host and r.port == port)]
+
+    if len(rules) == original_count:
+        console.print(f"[yellow]No rule found matching {host}:{port}[/yellow]")
+        return
+
+    save_network_rules(root, rules)
+    console.print(f"[green]✓[/green] Removed [cyan]{host}:{port}[/cyan]")
+
+    # Offer to apply immediately
+    _offer_apply(root)
+
+
+def _network_apply(args: argparse.Namespace):
+    """Apply current network rules to Snowflake."""
+    render_banner()
+    root = find_project_root()
+    rules = load_network_rules(root)
+
+    if not rules:
+        console.print("[yellow]No network rules to apply.[/yellow]")
+        console.print("Add rules with [cyan]snowclaw network add <host>[/cyan] first.")
+        return
+
+    console.print("[bold]Current network rules:[/bold]")
+    console.print(format_rules_table(rules))
+    console.print()
+
+    approved = inquirer.confirm(
+        message=f"Apply {len(rules)} rule(s) to Snowflake?",
+        default=True,
+    ).execute()
+
+    if not approved:
+        console.print("[dim]Aborted.[/dim]")
+        return
+
+    ctx = load_snowflake_context(root)
+    if not ctx["account"] or not ctx["token"]:
+        console.print("[red]Missing Snowflake credentials in .env.[/red]")
+        sys.exit(1)
+
+    success = apply_network_rules(ctx["account"], ctx["token"], ctx["names"], rules)
+    if success:
+        console.print()
+        console.print("[green]Network rules applied to Snowflake.[/green]")
+    else:
+        console.print()
+        console.print("[red]Failed to apply network rules.[/red]")
+        sys.exit(1)
+
+
+def _network_detect(args: argparse.Namespace):
+    """Auto-detect required network rules from project config."""
+    render_banner()
+    root = find_project_root()
+
+    current = load_network_rules(root)
+    detected = detect_required_rules(root)
+
+    if not detected:
+        console.print("[dim]No external access requirements detected in config.[/dim]")
+        return
+
+    console.print("[bold]Detected network rules from project config:[/bold]")
+    console.print(format_rules_table(detected, title="Detected Rules"))
+
+    if current:
+        added, removed = diff_rules(current, detected)
+        if added or removed:
+            console.print()
+            console.print("[bold]Changes vs. current rules:[/bold]")
+            print_diff(added, removed)
+        else:
+            console.print()
+            console.print("[dim]Current rules already match detected requirements.[/dim]")
+            return
+
+    console.print()
+    save_rules = inquirer.confirm(
+        message="Save detected rules?",
+        default=True,
+    ).execute()
+
+    if save_rules:
+        if current:
+            # Merge detected into current
+            added, removed = diff_rules(current, detected)
+            removed_set = {(r.host, r.port) for r in removed}
+            merged = [r for r in current if (r.host, r.port) not in removed_set]
+            existing_set = {(r.host, r.port) for r in merged}
+            for r in added:
+                if (r.host, r.port) not in existing_set:
+                    merged.append(r)
+            save_network_rules(root, merged)
+        else:
+            save_network_rules(root, detected)
+        console.print("[green]✓[/green] Network rules saved.")
+        _offer_apply(root)
+    else:
+        console.print("[dim]Rules not saved.[/dim]")
+
+
+def _offer_apply(root: Path):
+    """Ask whether to apply rules to Snowflake now."""
+    apply_now = inquirer.confirm(
+        message="Apply to Snowflake now?",
+        default=False,
+    ).execute()
+
+    if apply_now:
+        ctx = load_snowflake_context(root)
+        if not ctx["account"] or not ctx["token"]:
+            console.print("[red]Missing Snowflake credentials in .env.[/red]")
+            return
+        rules = load_network_rules(root)
+        success = apply_network_rules(ctx["account"], ctx["token"], ctx["names"], rules)
+        if success:
+            console.print("[green]Network rules applied to Snowflake.[/green]")
+        else:
+            console.print("[red]Failed to apply. Retry with [cyan]snowclaw network apply[/cyan].[/red]")

--- a/snowclaw/network.py
+++ b/snowclaw/network.py
@@ -1,0 +1,343 @@
+"""Network rule management for SPCS external access."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
+from rich.table import Table
+
+from snowclaw.utils import console, snowflake_rest_execute
+
+
+@dataclass(frozen=True)
+class NetworkRule:
+    """A single host:port egress rule."""
+
+    host: str
+    port: int = 443
+    reason: str = ""
+
+    @property
+    def host_port(self) -> str:
+        return f"{self.host}:{self.port}"
+
+    def __eq__(self, other):
+        if isinstance(other, NetworkRule):
+            return self.host == other.host and self.port == other.port
+        return NotImplemented
+
+    def __hash__(self):
+        return hash((self.host, self.port))
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+RULES_FILE = "network-rules.json"
+
+
+def _rules_path(root: Path) -> Path:
+    return root / ".snowclaw" / RULES_FILE
+
+
+def load_network_rules(root: Path) -> list[NetworkRule]:
+    """Load network rules from .snowclaw/network-rules.json."""
+    path = _rules_path(root)
+    if not path.exists():
+        return []
+    data = json.loads(path.read_text())
+    return [NetworkRule(**r) for r in data.get("rules", [])]
+
+
+def save_network_rules(root: Path, rules: list[NetworkRule]):
+    """Save network rules to .snowclaw/network-rules.json."""
+    path = _rules_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {"rules": [asdict(r) for r in rules]}
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Auto-detection
+# ---------------------------------------------------------------------------
+
+# Known service -> required hosts mapping
+_KNOWN_HOSTS: dict[str, list[NetworkRule]] = {
+    "cortex": [
+        NetworkRule("*.snowflakecomputing.com", 443, "Snowflake Cortex & APIs"),
+    ],
+    "slack": [
+        NetworkRule("api.slack.com", 443, "Slack Web API"),
+        NetworkRule("wss-primary.slack.com", 443, "Slack WebSocket (primary)"),
+        NetworkRule("wss-backup.slack.com", 443, "Slack WebSocket (backup)"),
+    ],
+}
+
+
+def detect_required_rules(root: Path) -> list[NetworkRule]:
+    """Scan project config to detect which network rules are required.
+
+    Reads openclaw.json to find provider baseUrls and enabled channels.
+    """
+    rules: list[NetworkRule] = []
+
+    # Always need Snowflake access
+    rules.extend(_KNOWN_HOSTS["cortex"])
+
+    config_path = root / "openclaw.json"
+    if not config_path.exists():
+        return _dedup(rules)
+
+    config = json.loads(config_path.read_text())
+
+    # Scan provider baseUrls
+    providers = config.get("models", {}).get("providers", {})
+    for name, provider in providers.items():
+        base_url = provider.get("baseUrl", "")
+        if not base_url:
+            continue
+        parsed = urlparse(base_url)
+        host = parsed.hostname
+        port = parsed.port or 443
+        if host and not host.endswith(".snowflakecomputing.com"):
+            rules.append(NetworkRule(host, port, f"{name} provider"))
+
+    # Scan channels for Slack
+    channels = config.get("channels", {})
+    if "slack" in channels and channels["slack"].get("enabled", False):
+        rules.extend(_KNOWN_HOSTS["slack"])
+
+    return _dedup(rules)
+
+
+def _dedup(rules: list[NetworkRule]) -> list[NetworkRule]:
+    """Deduplicate rules by (host, port), preserving order."""
+    seen: set[tuple[str, int]] = set()
+    result: list[NetworkRule] = []
+    for r in rules:
+        key = (r.host, r.port)
+        if key not in seen:
+            seen.add(key)
+            result.append(r)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Diff
+# ---------------------------------------------------------------------------
+
+
+def diff_rules(
+    current: list[NetworkRule], required: list[NetworkRule]
+) -> tuple[list[NetworkRule], list[NetworkRule]]:
+    """Compare current rules against required rules.
+
+    Returns (added, removed) where:
+    - added: rules in required but not in current
+    - removed: rules in current but not in required
+    """
+    current_set = {(r.host, r.port) for r in current}
+    required_set = {(r.host, r.port) for r in required}
+
+    added = [r for r in required if (r.host, r.port) not in current_set]
+    removed = [r for r in current if (r.host, r.port) not in required_set]
+    return added, removed
+
+
+# ---------------------------------------------------------------------------
+# Display
+# ---------------------------------------------------------------------------
+
+
+def format_rules_table(
+    rules: list[NetworkRule], title: str = "Network Rules"
+) -> Table:
+    """Create a Rich table displaying network rules."""
+    table = Table(title=title, show_lines=False, expand=False)
+    table.add_column("Host", style="cyan")
+    table.add_column("Port", style="dim", justify="right")
+    table.add_column("Reason", style="dim")
+    for r in rules:
+        table.add_row(r.host, str(r.port), r.reason)
+    return table
+
+
+def print_diff(added: list[NetworkRule], removed: list[NetworkRule]):
+    """Print a diff of rule changes."""
+    for r in added:
+        console.print(
+            f"  [green]+[/green] [cyan]{r.host_port}[/cyan]  [dim]{r.reason}[/dim]"
+        )
+    for r in removed:
+        console.print(
+            f"  [red]-[/red] [cyan]{r.host_port}[/cyan]  [dim]{r.reason}[/dim]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# SQL generation
+# ---------------------------------------------------------------------------
+
+
+def build_network_rule_sql(names: dict, rules: list[NetworkRule]) -> list[str]:
+    """Build SQL statements to create/replace network rule and external access integration."""
+    if not rules:
+        return []
+
+    s = names["schema"]
+    value_list = ", ".join(f"'{r.host_port}'" for r in rules)
+
+    return [
+        (
+            f"CREATE OR REPLACE NETWORK RULE {s}.{names['egress_rule']} "
+            f"MODE = EGRESS TYPE = HOST_PORT VALUE_LIST = ({value_list})"
+        ),
+        (
+            f"CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION {names['external_access']} "
+            f"ALLOWED_NETWORK_RULES = ({s}.{names['egress_rule']}) "
+            "ENABLED = TRUE"
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Apply to Snowflake
+# ---------------------------------------------------------------------------
+
+
+def apply_network_rules(
+    account: str, pat: str, names: dict, rules: list[NetworkRule]
+) -> bool:
+    """Apply network rules to Snowflake via REST API.
+
+    Returns True if successful, False otherwise.
+    """
+    stmts = build_network_rule_sql(names, rules)
+    if not stmts:
+        console.print("  [dim]No network rules to apply.[/dim]")
+        return True
+
+    _LABEL_RE = re.compile(
+        r"(?:CREATE|REPLACE)\s+(?:OR\s+REPLACE\s+)?(\w[\w\s]+?)\s+\S+\.\S+",
+        re.IGNORECASE,
+    )
+
+    with console.status("[bold cyan]Applying network rules..."):
+        for stmt in stmts:
+            try:
+                snowflake_rest_execute(account, pat, stmt)
+                m = _LABEL_RE.search(stmt)
+                label = m.group(0).split("REPLACE ")[-1] if m else stmt[:60]
+                console.print(f"  [green]✓[/green] {label}")
+            except requests.HTTPError as e:
+                console.print(f"  [red]✗[/red] Failed: {stmt[:80]}...")
+                console.print(f"    [dim]{e}[/dim]")
+                return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Interactive approval flow
+# ---------------------------------------------------------------------------
+
+
+def prompt_and_apply_rules(
+    root: Path,
+    account: str,
+    pat: str,
+    names: dict,
+    detected: list[NetworkRule] | None = None,
+) -> list[NetworkRule]:
+    """Detect required rules, show diff, prompt for approval, and apply.
+
+    Returns the final approved rule list.
+    """
+    from InquirerPy import inquirer
+
+    current = load_network_rules(root)
+    if detected is None:
+        detected = detect_required_rules(root)
+
+    # First-time setup: no existing rules
+    if not current:
+        if not detected:
+            console.print("[dim]No network rules required.[/dim]")
+            return []
+
+        console.print()
+        console.print("[bold]The following network rules are required for external access:[/bold]")
+        for r in detected:
+            console.print(
+                f"  [green]+[/green] [cyan]{r.host_port}[/cyan]  [dim]{r.reason}[/dim]"
+            )
+
+        console.print()
+        approved = inquirer.confirm(
+            message="Approve these network rules?",
+            default=True,
+        ).execute()
+
+        if not approved:
+            console.print(
+                "[yellow]Network rules not approved. External access will be unavailable.[/yellow]"
+            )
+            return []
+
+        save_network_rules(root, detected)
+        apply_network_rules(account, pat, names, detected)
+        return detected
+
+    # Existing rules — check for changes
+    added, removed = diff_rules(current, detected)
+
+    if not added and not removed:
+        console.print("[dim]Network rules are up to date.[/dim]")
+        return current
+
+    console.print()
+    console.print("[bold]Network rule changes detected:[/bold]")
+    print_diff(added, removed)
+
+    console.print()
+    approved = inquirer.confirm(
+        message="Approve these changes?",
+        default=True,
+    ).execute()
+
+    if not approved:
+        console.print("[dim]Keeping existing network rules.[/dim]")
+        return current
+
+    # Merge: apply additions and removals
+    removed_set = {(r.host, r.port) for r in removed}
+    merged = [r for r in current if (r.host, r.port) not in removed_set]
+    existing_set = {(r.host, r.port) for r in merged}
+    for r in added:
+        if (r.host, r.port) not in existing_set:
+            merged.append(r)
+
+    save_network_rules(root, merged)
+    apply_network_rules(account, pat, names, merged)
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def parse_host_port(value: str) -> tuple[str, int]:
+    """Parse 'host:port' or 'host' into (host, port). Defaults port to 443."""
+    if ":" in value:
+        host, port_str = value.rsplit(":", 1)
+        try:
+            return host, int(port_str)
+        except ValueError:
+            pass
+    return value, 443

--- a/snowclaw/scaffold.py
+++ b/snowclaw/scaffold.py
@@ -7,7 +7,8 @@ import shutil
 import sys
 from pathlib import Path
 
-from snowclaw.utils import console, get_templates_dir, read_marker
+from snowclaw.network import build_network_rule_sql, load_network_rules
+from snowclaw.utils import console, get_templates_dir, read_marker, sf_names
 
 
 DOCKER_COMPOSE_TEMPLATE = """\
@@ -149,5 +150,19 @@ def assemble_build_context(root: Path) -> Path:
             content = content.replace("__SNOWCLAW_SCHEMA__", schema_name)
             content = content.replace("__SNOWCLAW_PREFIX__", prefix)
             (spcs_dir / name).write_text(content)
+
+    # Generate network-rules.sql from saved rules
+    names = sf_names(database, schema_name)
+    rules = load_network_rules(root)
+    if rules:
+        stmts = build_network_rule_sql(names, rules)
+        if stmts:
+            header = (
+                "-- Network rules (generated from .snowclaw/network-rules.json)\n"
+                "-- Manage with: snowclaw network list|add|remove|apply|detect\n\n"
+            )
+            (spcs_dir / "network-rules.sql").write_text(
+                header + ";\n\n".join(stmts) + ";\n"
+            )
 
     return build_dir

--- a/snowclaw/snowflake.py
+++ b/snowclaw/snowflake.py
@@ -10,7 +10,11 @@ from snowclaw.utils import console, sf_names, snowflake_rest_execute
 
 
 def build_setup_statements(names: dict) -> list[str]:
-    """Build SQL statements to create non-secret Snowflake objects from derived names."""
+    """Build SQL statements to create non-secret Snowflake objects from derived names.
+
+    Network rules and external access integrations are managed separately
+    via snowclaw.network — they are not included here.
+    """
     s = names["schema"]  # fully qualified: db.schema
     return [
         f"CREATE DATABASE IF NOT EXISTS {names['db']}",
@@ -19,18 +23,6 @@ def build_setup_statements(names: dict) -> list[str]:
         (
             f"CREATE STAGE IF NOT EXISTS {s}.{names['stage']} "
             "ENCRYPTION = (TYPE = 'SNOWFLAKE_SSE') DIRECTORY = (ENABLE = TRUE)"
-        ),
-        (
-            f"CREATE OR REPLACE NETWORK RULE {s}.{names['egress_rule']} "
-            "MODE = EGRESS TYPE = HOST_PORT VALUE_LIST = ("
-            "'openrouter.ai:443', 'api.slack.com:443', "
-            "'wss-primary.slack.com:443', 'wss-backup.slack.com:443', "
-            "'*.snowflakecomputing.com:443')"
-        ),
-        (
-            f"CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION {names['external_access']} "
-            f"ALLOWED_NETWORK_RULES = ({s}.{names['egress_rule']}) "
-            "ENABLED = TRUE"
         ),
         (
             f"CREATE COMPUTE POOL IF NOT EXISTS {names['pool']} "

--- a/templates/spcs/image-repo.sql
+++ b/templates/spcs/image-repo.sql
@@ -34,22 +34,9 @@ CREATE SECRET IF NOT EXISTS __SNOWCLAW_PREFIX___slack_app_token
   TYPE = GENERIC_STRING
   SECRET_STRING = '';
 
--- Network rule (references network-rules.yaml values)
-CREATE OR REPLACE NETWORK RULE __SNOWCLAW_PREFIX___egress_rule
-  MODE = EGRESS
-  TYPE = HOST_PORT
-  VALUE_LIST = (
-    'openrouter.ai:443',
-    'api.slack.com:443',
-    'wss-primary.slack.com:443',
-    'wss-backup.slack.com:443',
-    '*.snowflakecomputing.com:443'
-  );
-
--- External access integration
-CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION __SNOWCLAW_PREFIX___external_access
-  ALLOWED_NETWORK_RULES = (__SNOWCLAW_PREFIX___egress_rule)
-  ENABLED = TRUE;
+-- Network rules and external access integration are managed dynamically.
+-- Use `snowclaw network` to add, remove, and apply rules.
+-- Rules are stored in .snowclaw/network-rules.json and applied via REST API.
 
 -- Compute pool
 CREATE COMPUTE POOL IF NOT EXISTS __SNOWCLAW_PREFIX___pool


### PR DESCRIPTION
## Summary
- Adds `snowclaw network` CLI command with `list`, `add`, `remove`, `detect`, and `apply` subcommands for managing SPCS network rules
- Auto-detects required external hosts from `openclaw.json` (provider URLs, Slack endpoints) during `setup` and `deploy`, prompting for user approval before creating Snowflake objects
- Replaces hardcoded network rule/external access integration with dynamic rules persisted in `.snowclaw/network-rules.json`

## Test plan
- [ ] Run `snowclaw setup` and verify network rules are detected and approval prompt appears
- [ ] Run `snowclaw network list` / `add` / `remove` / `detect` / `apply` subcommands
- [ ] Run `snowclaw deploy` with changed config and verify diff is shown with approval prompt
- [ ] Verify `network-rules.sql` is generated in `.snowclaw/build/spcs/` during build
- [ ] Verify `image-repo.sql` no longer contains hardcoded network rules