### PR TITLE
Add curated tool management (GitHub CLI + Brave Search)

### DIFF
--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -16,6 +16,7 @@ from rich.panel import Panel
 from snowclaw import __version__
 from snowclaw.config import write_connections_toml, write_dotenv, write_openclaw_config
 from snowclaw.network import (
+    TOOL_REGISTRY,
     NetworkRule,
     apply_network_rules,
     detect_required_rules,
@@ -124,6 +125,29 @@ def cmd_setup(args: argparse.Namespace):
         slack_bot_token = inquirer.secret(message="Slack bot token (xoxb-...):", validate=lambda v: len(v.strip()) > 0).execute()
         slack_app_token = inquirer.secret(message="Slack app token (xapp-...):", validate=lambda v: len(v.strip()) > 0).execute()
 
+    # --- Developer tools ---
+    tools = inquirer.checkbox(
+        message="Developer tools to enable:",
+        choices=[
+            {"name": t["display_name"], "value": name, "enabled": t.get("default", False)}
+            for name, t in TOOL_REGISTRY.items()
+        ],
+    ).execute()
+
+    tool_credentials: dict[str, str] = {}
+    for tool_name in tools:
+        tool = TOOL_REGISTRY[tool_name]
+        for cred in tool["credentials"]:
+            if cred.get("secret"):
+                value = inquirer.secret(
+                    message=cred["prompt"],
+                    validate=lambda v: len(v.strip()) > 0,
+                    invalid_message=f"{cred['label']} is required.",
+                ).execute()
+            else:
+                value = inquirer.text(message=cred["prompt"]).execute()
+            tool_credentials[cred["env_var"]] = value.strip()
+
     warehouse = inquirer.text(message="Snowflake warehouse:", default="COMPUTE_WH").execute()
     role = inquirer.text(message="Snowflake role:", default="SYSADMIN").execute()
     database = inquirer.text(
@@ -153,6 +177,8 @@ def cmd_setup(args: argparse.Namespace):
         "role": role.strip(),
         "database": database,
         "schema": schema,
+        "tools": tools,
+        "tool_credentials": tool_credentials,
     }
 
     # --- Write .snowclaw marker ---
@@ -162,6 +188,7 @@ def cmd_setup(args: argparse.Namespace):
         "database": database,
         "schema": schema,
         "openclaw_version": "latest",
+        "tools": tools,
     }
     write_marker(root, marker)
 
@@ -404,6 +431,8 @@ def cmd_deploy(args: argparse.Namespace):
         names["secret_openrouter_key"]: env.get("OPENROUTER_API_KEY", ""),
         names["secret_slack_bot_token"]: env.get("SLACK_BOT_TOKEN", ""),
         names["secret_slack_app_token"]: env.get("SLACK_APP_TOKEN", ""),
+        names["secret_gh_token"]: env.get("GH_TOKEN", ""),
+        names["secret_brave_api_key"]: env.get("BRAVE_API_KEY", ""),
     }
     for secret_name, value in secret_map.items():
         if value:

--- a/snowclaw/config.py
+++ b/snowclaw/config.py
@@ -26,6 +26,12 @@ def write_dotenv(root: Path, settings: dict):
     if settings.get("slack_app_token"):
         lines.append(f"SLACK_APP_TOKEN={settings['slack_app_token']}")
 
+    # Tool credentials
+    tool_credentials = settings.get("tool_credentials", {})
+    for env_var, value in tool_credentials.items():
+        if value:
+            lines.append(f"{env_var}={value}")
+
     (root / ".env").write_text("\n".join(lines) + "\n")
     console.print(f"  [green]✓[/green] Wrote {root / '.env'}")
 
@@ -81,6 +87,16 @@ def write_openclaw_config(root: Path, settings: dict):
                     "appToken": "${SLACK_APP_TOKEN}",
                 }
             },
+        }
+
+    # Brave Search tool (optional)
+    if "brave_search" in settings.get("tools", []):
+        config["tools"] = {
+            "web": {
+                "search": {
+                    "provider": "brave",
+                }
+            }
         }
 
     config_path = root / "openclaw.json"

--- a/snowclaw/network.py
+++ b/snowclaw/network.py
@@ -80,6 +80,47 @@ _KNOWN_HOSTS: dict[str, list[NetworkRule]] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Tool registry — curated developer tools that need credentials + network rules
+# ---------------------------------------------------------------------------
+
+TOOL_REGISTRY: dict[str, dict] = {
+    "github": {
+        "display_name": "GitHub (gh CLI + git auth)",
+        "hosts": [
+            NetworkRule("github.com", 443, "GitHub"),
+            NetworkRule("api.github.com", 443, "GitHub API"),
+        ],
+        "credentials": [
+            {
+                "key": "GH_TOKEN",
+                "env_var": "GH_TOKEN",
+                "label": "GitHub personal access token",
+                "prompt": "GitHub personal access token (PAT):",
+                "secret": True,
+            },
+        ],
+        "default": True,
+    },
+    "brave_search": {
+        "display_name": "Brave Search (web search for agent)",
+        "hosts": [
+            NetworkRule("api.brave.com", 443, "Brave Search API"),
+        ],
+        "credentials": [
+            {
+                "key": "BRAVE_API_KEY",
+                "env_var": "BRAVE_API_KEY",
+                "label": "Brave Search API key",
+                "prompt": "Brave Search API key (brave.com/search/api):",
+                "secret": True,
+            },
+        ],
+        "default": False,
+    },
+}
+
+
 def detect_required_rules(root: Path) -> list[NetworkRule]:
     """Scan project config to detect which network rules are required.
 
@@ -112,6 +153,18 @@ def detect_required_rules(root: Path) -> list[NetworkRule]:
     channels = config.get("channels", {})
     if "slack" in channels and channels["slack"].get("enabled", False):
         rules.extend(_KNOWN_HOSTS["slack"])
+
+    # Include hosts for enabled tools (read from marker)
+    marker_path = root / ".snowclaw" / "config.json"
+    enabled_tools: list[str] = []
+    if marker_path.exists():
+        marker = json.loads(marker_path.read_text())
+        enabled_tools = marker.get("tools", [])
+
+    for tool_name in enabled_tools:
+        tool = TOOL_REGISTRY.get(tool_name)
+        if tool:
+            rules.extend(tool["hosts"])
 
     return _dedup(rules)
 

--- a/snowclaw/snowflake.py
+++ b/snowclaw/snowflake.py
@@ -68,6 +68,22 @@ def run_snowflake_setup(settings: dict):
         )
         secret_stmts.append((stmt, f"{s}.{secret_name}"))
 
+    # Tool credential secrets
+    tool_credentials = settings.get("tool_credentials", {})
+    tool_secret_map = {
+        "GH_TOKEN": names["secret_gh_token"],
+        "BRAVE_API_KEY": names["secret_brave_api_key"],
+    }
+    for env_var, secret_name in tool_secret_map.items():
+        value = tool_credentials.get(env_var, "")
+        if value:
+            escaped = value.replace("'", "\\'")
+            stmt = (
+                f"CREATE OR REPLACE SECRET {s}.{secret_name} "
+                f"TYPE = GENERIC_STRING SECRET_STRING = '{escaped}'"
+            )
+            secret_stmts.append((stmt, f"{s}.{secret_name}"))
+
     def _execute(stmt: str, label: str | None = None):
         if not label:
             m = _LABEL_RE.search(stmt)

--- a/snowclaw/utils.py
+++ b/snowclaw/utils.py
@@ -39,6 +39,8 @@ def sf_names(database: str, schema: str) -> dict:
         "secret_openrouter_key": f"{prefix}_openrouter_key",
         "secret_slack_bot_token": f"{prefix}_slack_bot_token",
         "secret_slack_app_token": f"{prefix}_slack_app_token",
+        "secret_gh_token": f"{prefix}_gh_token",
+        "secret_brave_api_key": f"{prefix}_brave_api_key",
     }
 
 

--- a/templates/Dockerfile
+++ b/templates/Dockerfile
@@ -14,6 +14,14 @@ COPY --chown=1000:1000 config/connections.toml /home/node/.snowflake/connections
 RUN SKIP_PODMAN=1 NON_INTERACTIVE=1 \
  sh -c 'curl -LsS https://ai.snowflake.com/static/cc-scripts/install.sh | sh'
 
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
 # Ensure the openclaw home dir exists with correct ownership so volume mounts work
 USER root
 RUN mkdir -p /home/node/.openclaw && chown 1000:1000 /home/node/.openclaw

--- a/templates/scripts/docker-entrypoint.sh
+++ b/templates/scripts/docker-entrypoint.sh
@@ -29,4 +29,9 @@ mkdir -p "$OPENCLAW_HOME/workspace"
   done
 ) &
 
+# If GH_TOKEN is set, configure gh + git credential helper
+if [ -n "$GH_TOKEN" ]; then
+  gh auth setup-git 2>/dev/null || true
+fi
+
 exec "$@"

--- a/templates/spcs/service.yaml
+++ b/templates/spcs/service.yaml
@@ -15,6 +15,12 @@ spec:
         - snowflakeSecret: __SNOWCLAW_DB__.__SNOWCLAW_SCHEMA__.__SNOWCLAW_PREFIX___slack_app_token
           secretKeyRef: secret_string
           envVarName: SLACK_APP_TOKEN
+        - snowflakeSecret: __SNOWCLAW_DB__.__SNOWCLAW_SCHEMA__.__SNOWCLAW_PREFIX___gh_token
+          secretKeyRef: secret_string
+          envVarName: GH_TOKEN
+        - snowflakeSecret: __SNOWCLAW_DB__.__SNOWCLAW_SCHEMA__.__SNOWCLAW_PREFIX___brave_api_key
+          secretKeyRef: secret_string
+          envVarName: BRAVE_API_KEY
       resources:
         requests:
           cpu: 1


### PR DESCRIPTION
## Summary
- Introduces `TOOL_REGISTRY` in `network.py` — same composable pattern as `_KNOWN_HOSTS` for channels/providers
- Installs gh CLI in Dockerfile + wires `gh auth setup-git` in entrypoint (one PAT for both gh and git)
- Setup wizard prompts for tool selection + credentials (GitHub default-on, Brave Search optional)
- Snowflake Secrets created for tool credentials (`<prefix>_gh_token`, `<prefix>_brave_api_key`)
- Network rules auto-detected for enabled tools via marker
- Brave Search config generated in `openclaw.json` when enabled
- Tool secrets updated during deploy flow

## Test plan
- [ ] Run `snowclaw setup` and verify tool selection checkbox appears after Slack
- [ ] Select GitHub + Brave Search, verify credential prompts appear
- [ ] Verify `.env` contains `GH_TOKEN` and `BRAVE_API_KEY`
- [ ] Verify `openclaw.json` contains `tools.web.search.provider: "brave"` when Brave enabled
- [ ] Verify `.snowclaw/config.json` marker contains `"tools": ["github", "brave_search"]`
- [ ] Run `snowclaw network detect` and verify GitHub/Brave hosts appear
- [ ] Run `snowclaw dev` and verify Docker build succeeds with gh CLI install
- [ ] Verify `gh auth setup-git` runs on container start when `GH_TOKEN` is set

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)