### PR TITLE
fix: replace OWNER placeholder in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# SnowClaw installer — curl -fsSL https://raw.githubusercontent.com/OWNER/snowclaw/main/install.sh | bash
+# SnowClaw installer — curl -fsSL https://raw.githubusercontent.com/JacobScott98/SnowClaw/main/install.sh | bash
 set -euo pipefail
 
-REPO="https://github.com/OWNER/snowclaw.git"
+REPO="https://github.com/JacobScott98/SnowClaw.git"
 INSTALL_DIR="${SNOWCLAW_DIR:-$HOME/snowclaw}"
 MIN_PYTHON="3.10"
 


### PR DESCRIPTION
The install script had `OWNER` as a placeholder in both the curl one-liner comment and the `REPO` variable. Replaced with `JacobScott98/SnowClaw` so the installer actually works.