### PR TITLE
refactor: unify account and registry_account into single account_id

### DIFF
--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -77,15 +77,9 @@ def cmd_setup(args: argparse.Namespace):
 
     # --- Collect inputs ---
     account = inquirer.text(
-        message="Snowflake account locator:",
+        message="Snowflake account identifier (orgname-accountname):",
         validate=lambda v: len(v.strip()) > 0,
-        invalid_message="Account locator is required.",
-    ).execute()
-
-    registry_account = inquirer.text(
-        message="Snowflake registry account (orgname-accountname, for SPCS image push):",
-        validate=lambda v: len(v.strip()) > 0,
-        invalid_message="Registry account is required for SPCS deployments.",
+        invalid_message="Account identifier is required.",
     ).execute()
 
     sf_user = inquirer.text(
@@ -141,7 +135,6 @@ def cmd_setup(args: argparse.Namespace):
 
     settings = {
         "account": account.strip(),
-        "registry_account": registry_account.strip(),
         "sf_user": sf_user.strip(),
         "pat": pat.strip(),
         "enable_openrouter": "openrouter" in providers,
@@ -299,14 +292,13 @@ def cmd_deploy(args: argparse.Namespace):
 
     account = ctx["account"]
     token = ctx["token"]
-    registry_account = ctx["registry_account"]
     sf_user = ctx["user"]
     names = ctx["names"]
     env = ctx["env"]
 
-    if not all([account, token, registry_account, sf_user]):
+    if not all([account, token, sf_user]):
         console.print("[red]Missing required environment variables in .env.[/red]")
-        console.print("Required: SNOWFLAKE_ACCOUNT, SNOWFLAKE_TOKEN, SNOWFLAKE_REGISTRY_ACCOUNT, SNOWFLAKE_USER")
+        console.print("Required: SNOWFLAKE_ACCOUNT, SNOWFLAKE_TOKEN, SNOWFLAKE_USER")
         sys.exit(1)
 
     image_tag = env.get("IMAGE_TAG", "latest")
@@ -315,7 +307,7 @@ def cmd_deploy(args: argparse.Namespace):
     fqn_schema = names["schema"]
     warehouse = ctx["warehouse"]
     repo = names["repo"]
-    registry_host = f"{registry_account}.registry.snowflakecomputing.com"
+    registry_host = f"{account}.registry.snowflakecomputing.com"
     image_repo = f"{registry_host}/{db}/{schema_name}/{repo}"
 
     # Check network rules before deploying

--- a/snowclaw/config.py
+++ b/snowclaw/config.py
@@ -15,7 +15,6 @@ def write_dotenv(root: Path, settings: dict):
         f"SNOWCLAW_DB={settings['database']}",
         f"SNOWCLAW_SCHEMA={settings['schema']}",
         f"SNOWFLAKE_ACCOUNT={settings['account']}",
-        f"SNOWFLAKE_REGISTRY_ACCOUNT={settings['registry_account']}",
         f"SNOWFLAKE_USER={settings['sf_user']}",
         f"SNOWFLAKE_TOKEN={settings['pat']}",
     ]

--- a/snowclaw/utils.py
+++ b/snowclaw/utils.py
@@ -150,7 +150,7 @@ def snowflake_rest_execute(
 def load_snowflake_context(root: Path) -> dict:
     """Load Snowflake connection context from marker + .env + connections.toml.
 
-    Returns dict with: account, token, user, registry_account, database, schema,
+    Returns dict with: account, token, user, database, schema,
     warehouse, names (from sf_names), and the raw env/conn dicts.
     """
     import os as _os
@@ -165,7 +165,6 @@ def load_snowflake_context(root: Path) -> dict:
 
     account = env.get("SNOWFLAKE_ACCOUNT")
     token = env.get("SNOWFLAKE_TOKEN")
-    registry_account = env.get("SNOWFLAKE_REGISTRY_ACCOUNT")
     sf_user = env.get("SNOWFLAKE_USER")
     warehouse = env.get("SNOWFLAKE_WAREHOUSE") or conn.get("warehouse")
 
@@ -173,7 +172,6 @@ def load_snowflake_context(root: Path) -> dict:
         "account": account,
         "token": token,
         "user": sf_user,
-        "registry_account": registry_account,
         "database": database,
         "schema": schema,
         "warehouse": warehouse,


### PR DESCRIPTION
The Snowflake account identifier (orgname-accountname format) works for both the Cortex REST API and the Docker registry, so there's no need to collect it twice.

**Changes:**
- Removed the separate `registry_account` setup prompt — now just one `account` field with clearer messaging
- Dropped `SNOWFLAKE_REGISTRY_ACCOUNT` from `.env` generation
- `cmd_deploy` uses the unified `account` for registry host
- Cleaned up `load_snowflake_context` to remove the redundant field

One fewer question during setup, one fewer env var to manage.