### PR TITLE
feat: add snowclaw status command

### DIFF
--- a/snowclaw/cli.py
+++ b/snowclaw/cli.py
@@ -13,6 +13,7 @@ from snowclaw.commands import (
     cmd_pull,
     cmd_push,
     cmd_setup,
+    cmd_status,
     cmd_update,
 )
 
@@ -31,6 +32,7 @@ def build_parser() -> argparse.ArgumentParser:
     build_parser = sub.add_parser("build", help="Assemble build context and build Docker image")
     build_parser.add_argument("--tag", default="latest", help="Docker image tag (default: latest)")
     sub.add_parser("deploy", help="Build, push, and deploy to SPCS")
+    sub.add_parser("status", help="Show deployed service status, endpoints, and compute pool")
     sub.add_parser("update", help="Update the OpenClaw version")
 
     pull_parser = sub.add_parser("pull", help="Pull skills and workspace from SPCS stage")
@@ -73,6 +75,7 @@ def main():
         "dev": cmd_dev,
         "build": cmd_build,
         "deploy": cmd_deploy,
+        "status": cmd_status,
         "update": cmd_update,
         "pull": cmd_pull,
         "push": cmd_push,

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -798,6 +798,146 @@ def _network_detect(args: argparse.Namespace):
         console.print("[dim]Rules not saved.[/dim]")
 
 
+def cmd_status(args: argparse.Namespace):
+    """Show the current state of the deployed OpenClaw instance."""
+    render_banner()
+    root = find_project_root()
+    ctx = load_snowflake_context(root)
+
+    account = ctx["account"]
+    token = ctx["token"]
+    names = ctx["names"]
+
+    if not account or not token:
+        console.print("[red]Missing Snowflake credentials in .env.[/red]")
+        console.print("Required: SNOWFLAKE_ACCOUNT, SNOWFLAKE_TOKEN")
+        sys.exit(1)
+
+    db = names["db"]
+    schema_name = names["schema_name"]
+    fqn_schema = names["schema"]
+    warehouse = ctx["warehouse"]
+    service_name = names["service"]
+    pool_name = names["pool"]
+
+    STATUS_COLORS = {
+        "RUNNING": "[green]🟢 RUNNING[/green]",
+        "READY": "[green]🟢 READY[/green]",
+        "ACTIVE": "[green]🟢 ACTIVE[/green]",
+        "PENDING": "[yellow]🟡 PENDING[/yellow]",
+        "STARTING": "[yellow]🟡 STARTING[/yellow]",
+        "IDLE": "[yellow]🟡 IDLE[/yellow]",
+        "SUSPENDING": "[yellow]🟡 SUSPENDING[/yellow]",
+        "RESUMING": "[yellow]🟡 RESUMING[/yellow]",
+        "FAILED": "[red]🔴 FAILED[/red]",
+        "SUSPENDED": "[red]🔴 SUSPENDED[/red]",
+    }
+
+    def fmt_status(status: str) -> str:
+        return STATUS_COLORS.get(status.upper(), f"[dim]{status}[/dim]")
+
+    # --- Service Status ---
+    console.print(f"[bold]Service:[/bold] {service_name}")
+    service_ok = False
+    try:
+        data = snowflake_rest_execute(
+            account, token,
+            f"DESCRIBE SERVICE {fqn_schema}.{service_name}",
+            database=db, schema=schema_name, warehouse=warehouse,
+        )
+        rows = data.get("data", [])
+        if rows:
+            service_ok = True
+            # DESCRIBE SERVICE returns rows with service properties
+            # Columns typically: name, database_name, schema_name, owner, compute_pool,
+            # ... status is usually in the row data
+            # We'll look at resultSetMetaData to find column positions
+            columns = [
+                col["name"].upper()
+                for col in data.get("resultSetMetaData", {}).get("rowType", [])
+            ]
+            row = rows[0]
+            col_map = {c: i for i, c in enumerate(columns)}
+
+            status_val = row[col_map["STATUS"]] if "STATUS" in col_map else "UNKNOWN"
+            console.print(f"[bold]Status:[/bold]  {fmt_status(status_val)}")
+
+            if "CREATED_ON" in col_map:
+                console.print(f"[bold]Created:[/bold] [dim]{row[col_map['CREATED_ON']]}[/dim]")
+            if "NUM_INSTANCES" in col_map:
+                console.print(f"[bold]Instances:[/bold] {row[col_map['NUM_INSTANCES']]}")
+        else:
+            console.print("[bold]Status:[/bold]  [red]🔴 No data returned[/red]")
+    except requests.HTTPError:
+        console.print("[bold]Status:[/bold]  [red]🔴 Service not found[/red]")
+        console.print("[dim]Deploy with [cyan]snowclaw deploy[/cyan] first.[/dim]")
+
+    # --- Endpoints ---
+    console.print()
+    if service_ok:
+        try:
+            data = snowflake_rest_execute(
+                account, token,
+                f"SHOW ENDPOINTS IN SERVICE {fqn_schema}.{service_name}",
+                database=db, schema=schema_name,
+            )
+            rows = data.get("data", [])
+            if rows:
+                columns = [
+                    col["name"].upper()
+                    for col in data.get("resultSetMetaData", {}).get("rowType", [])
+                ]
+                col_map = {c: i for i, c in enumerate(columns)}
+                name_idx = col_map.get("NAME", 0)
+                url_idx = col_map.get("INGRESS_URL", col_map.get("URL", 1))
+
+                console.print("[bold]Endpoints:[/bold]")
+                for row in rows:
+                    ep_name = row[name_idx] if name_idx < len(row) else "?"
+                    ep_url = row[url_idx] if url_idx < len(row) else "?"
+                    console.print(f"  {ep_name} → [cyan]{ep_url}[/cyan]")
+            else:
+                console.print("[bold]Endpoints:[/bold] [dim]None available yet[/dim]")
+        except requests.HTTPError:
+            console.print("[bold]Endpoints:[/bold] [dim]Could not retrieve endpoints[/dim]")
+    else:
+        console.print("[bold]Endpoints:[/bold] [dim]N/A (service not found)[/dim]")
+
+    # --- Compute Pool ---
+    console.print()
+    console.print(f"[bold]Compute Pool:[/bold] {pool_name}")
+    try:
+        data = snowflake_rest_execute(
+            account, token,
+            f"DESCRIBE COMPUTE POOL {pool_name}",
+            database=db, schema=schema_name, warehouse=warehouse,
+        )
+        rows = data.get("data", [])
+        if rows:
+            columns = [
+                col["name"].upper()
+                for col in data.get("resultSetMetaData", {}).get("rowType", [])
+            ]
+            row = rows[0]
+            col_map = {c: i for i, c in enumerate(columns)}
+
+            pool_status = row[col_map["STATE"]] if "STATE" in col_map else "UNKNOWN"
+            console.print(f"[bold]Status:[/bold]       {fmt_status(pool_status)}")
+
+            if "INSTANCE_FAMILY" in col_map:
+                console.print(f"[bold]Instance:[/bold]     {row[col_map['INSTANCE_FAMILY']]}")
+            if "MIN_NODES" in col_map and "MAX_NODES" in col_map:
+                min_n = row[col_map["MIN_NODES"]]
+                max_n = row[col_map["MAX_NODES"]]
+                console.print(f"[bold]Nodes:[/bold]        {min_n}/{max_n} (min/max)")
+            if "NUM_SERVICES" in col_map:
+                console.print(f"[bold]Services:[/bold]     {row[col_map['NUM_SERVICES']]}")
+    except requests.HTTPError:
+        console.print("[bold]Status:[/bold]       [red]🔴 Compute pool not found[/red]")
+
+    console.print()
+
+
 def _offer_apply(root: Path):
     """Ask whether to apply rules to Snowflake now."""
     apply_now = inquirer.confirm(


### PR DESCRIPTION
Adds `snowclaw status` to show the current state of a deployed OpenClaw instance:

- **Service status** — RUNNING/SUSPENDED/PENDING with color-coded indicators
- **Endpoints** — lists all service endpoint URLs
- **Compute pool** — state, instance family, node counts (min/max)

Uses column metadata from REST API responses (not hardcoded indices). Gracefully handles missing services, pools, or credentials.

Changes:
- `snowclaw/commands.py` — new `cmd_status()` (+140 lines)
- `snowclaw/cli.py` — registered `status` subcommand