### PR TITLE
feat: sync openclaw.json config to/from stage

### DIFF
--- a/snowclaw/cli.py
+++ b/snowclaw/cli.py
@@ -33,15 +33,17 @@ def build_parser() -> argparse.ArgumentParser:
     sub.add_parser("deploy", help="Build, push, and deploy to SPCS")
     sub.add_parser("update", help="Update the OpenClaw version")
 
-    pull_parser = sub.add_parser("pull", help="Pull skills and workspace from SPCS stage")
+    pull_parser = sub.add_parser("pull", help="Pull skills, workspace, and config from SPCS stage")
     pull_group = pull_parser.add_mutually_exclusive_group()
     pull_group.add_argument("--workspace-only", action="store_true", help="Only pull workspace/")
     pull_group.add_argument("--skills-only", action="store_true", help="Only pull skills/")
+    pull_group.add_argument("--config-only", action="store_true", help="Only pull openclaw.json")
 
-    push_parser = sub.add_parser("push", help="Push skills and workspace to SPCS stage")
+    push_parser = sub.add_parser("push", help="Push skills, workspace, and config to SPCS stage")
     push_group = push_parser.add_mutually_exclusive_group()
     push_group.add_argument("--workspace-only", action="store_true", help="Only push workspace/")
     push_group.add_argument("--skills-only", action="store_true", help="Only push skills/")
+    push_group.add_argument("--config-only", action="store_true", help="Only push openclaw.json")
 
     # --- snowclaw network ---
     net_parser = sub.add_parser(

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -500,17 +500,19 @@ def cmd_update(args: argparse.Namespace):
 
 
 def _sync_targets(args: argparse.Namespace) -> list[str]:
-    """Determine which directories to sync based on CLI flags."""
+    """Determine which targets to sync based on CLI flags."""
     if getattr(args, "workspace_only", False):
         return ["workspace"]
     if getattr(args, "skills_only", False):
         return ["skills"]
-    return ["skills", "workspace"]
+    if getattr(args, "config_only", False):
+        return ["config"]
+    return ["skills", "workspace", "config"]
 
 
 def cmd_pull(args: argparse.Namespace):
-    """Pull skills and/or workspace from SPCS stage."""
-    from snowclaw.stage import get_sf_connection, pull_directory
+    """Pull skills, workspace, and/or config from SPCS stage."""
+    from snowclaw.stage import get_sf_connection, pull_directory, stage_list, stage_pull_file
 
     render_banner()
     root = find_project_root()
@@ -539,14 +541,24 @@ def cmd_pull(args: argparse.Namespace):
     )
     try:
         for target in targets:
-            local_dir = root / target
-            local_dir.mkdir(parents=True, exist_ok=True)
-            console.print(f"[bold]Pulling {target}/...[/bold]")
-            downloaded = pull_directory(conn, fqn_stage, target, local_dir)
-            for f in downloaded:
-                console.print(f"  [green]✓[/green] {target}/{f}")
-            if not downloaded:
-                console.print(f"  [dim]No files found on stage for {target}/[/dim]")
+            if target == "config":
+                console.print("[bold]Pulling openclaw.json...[/bold]")
+                # Check if openclaw.json exists on stage
+                files = stage_list(conn, fqn_stage, prefix="openclaw.json")
+                if not files:
+                    console.print("  [dim]No openclaw.json found on stage[/dim]")
+                    continue
+                stage_pull_file(conn, fqn_stage, "openclaw.json", str(root))
+                console.print("  [green]✓[/green] Pulled openclaw.json")
+            else:
+                local_dir = root / target
+                local_dir.mkdir(parents=True, exist_ok=True)
+                console.print(f"[bold]Pulling {target}/...[/bold]")
+                downloaded = pull_directory(conn, fqn_stage, target, local_dir)
+                for f in downloaded:
+                    console.print(f"  [green]✓[/green] {target}/{f}")
+                if not downloaded:
+                    console.print(f"  [dim]No files found on stage for {target}/[/dim]")
     finally:
         conn.close()
 
@@ -555,8 +567,8 @@ def cmd_pull(args: argparse.Namespace):
 
 
 def cmd_push(args: argparse.Namespace):
-    """Push skills and/or workspace to SPCS stage."""
-    from snowclaw.stage import get_sf_connection, push_directory
+    """Push skills, workspace, and/or config to SPCS stage."""
+    from snowclaw.stage import get_sf_connection, push_directory, stage_push_file
 
     render_banner()
     root = find_project_root()
@@ -585,16 +597,25 @@ def cmd_push(args: argparse.Namespace):
     )
     try:
         for target in targets:
-            local_dir = root / target
-            if not local_dir.is_dir():
-                console.print(f"  [dim]Skipping {target}/ (directory not found)[/dim]")
-                continue
-            console.print(f"[bold]Pushing {target}/...[/bold]")
-            uploaded = push_directory(conn, fqn_stage, target, local_dir)
-            for f in uploaded:
-                console.print(f"  [green]✓[/green] {target}/{f}")
-            if not uploaded:
-                console.print(f"  [dim]No files to upload in {target}/[/dim]")
+            if target == "config":
+                config_file = root / "openclaw.json"
+                if not config_file.is_file():
+                    console.print("  [dim]Skipping openclaw.json (file not found)[/dim]")
+                    continue
+                console.print("[bold]Pushing openclaw.json...[/bold]")
+                stage_push_file(conn, fqn_stage, str(config_file), "")
+                console.print("  [green]✓[/green] Pushed openclaw.json")
+            else:
+                local_dir = root / target
+                if not local_dir.is_dir():
+                    console.print(f"  [dim]Skipping {target}/ (directory not found)[/dim]")
+                    continue
+                console.print(f"[bold]Pushing {target}/...[/bold]")
+                uploaded = push_directory(conn, fqn_stage, target, local_dir)
+                for f in uploaded:
+                    console.print(f"  [green]✓[/green] {target}/{f}")
+                if not uploaded:
+                    console.print(f"  [dim]No files to upload in {target}/[/dim]")
     finally:
         conn.close()
 


### PR DESCRIPTION
Updates `snowclaw push` and `snowclaw pull` to support syncing `openclaw.json` to/from the Snowflake stage.

### Changes:
- **Config sync**: `openclaw.json` is now a first-class sync target alongside skills/ and workspace/
- **New flag**: `--config-only` for both push and pull
- **Default behavior**: no flags syncs all three (skills + workspace + config)
- **Semantics**: stage wins on pull (overwrites local), local wins on push (overwrites stage)
- Gracefully handles missing config on stage during pull

### Why:
OpenClaw reads `openclaw.json` at runtime and may modify it via the gateway UI. Keeping it on the stage means config changes (e.g. `snowclaw channel add`) take effect without a full rebuild/redeploy, and gateway UI changes persist across container restarts.

### Files:
- `snowclaw/cli.py` — added `--config-only` to push/pull argument groups
- `snowclaw/commands.py` — updated `_sync_targets()`, `cmd_push`, `cmd_pull` to handle single-file config sync