### PR TITLE
feat: dynamic secrets cleanup and deploy nudge after channel/tool changes

### DIFF
--- a/snowclaw/channels.py
+++ b/snowclaw/channels.py
@@ -451,6 +451,7 @@ def channel_add():
         border_style="green",
         expand=False,
     ))
+    console.print("[dim]Run [cyan]snowclaw deploy[/cyan] to apply changes to your SPCS service.[/dim]")
 
 
 def channel_remove(name: str | None):
@@ -494,6 +495,7 @@ def channel_remove(name: str | None):
         "[dim]Network rules were not removed. Use [cyan]snowclaw network detect[/cyan] "
         "to clean up unused rules.[/dim]"
     )
+    console.print("[dim]Run [cyan]snowclaw deploy[/cyan] to apply changes to your SPCS service.[/dim]")
 
 
 def channel_edit(name: str | None):
@@ -579,3 +581,4 @@ def channel_edit(name: str | None):
     console.print()
     console.print(f"[green]✓[/green] Updated {ct.display_name} / {account_name}")
     console.print(f"  [dim]Updated openclaw.json and .env[/dim]")
+    console.print("[dim]Run [cyan]snowclaw deploy[/cyan] to apply changes to your SPCS service.[/dim]")

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -434,8 +434,6 @@ def cmd_deploy(args: argparse.Namespace):
     console.print("[bold]Updating Snowflake secrets...[/bold]")
     secret_map = {
         names["secret_sf_token"]: token,
-        names["secret_slack_bot_token"]: env.get("SLACK_BOT_TOKEN", ""),
-        names["secret_slack_app_token"]: env.get("SLACK_APP_TOKEN", ""),
         names["secret_gh_token"]: env.get("GH_TOKEN", ""),
         names["secret_brave_api_key"]: env.get("BRAVE_API_KEY", ""),
     }


### PR DESCRIPTION
- Removes hardcoded Slack secret entries from cmd_deploy (now handled dynamically via channel registry)
- Adds deploy nudge reminder after channel add/edit/remove and tool add/remove
- Channel secrets are discovered dynamically from openclaw.json at deploy time