### PR TITLE
feat: add snowclaw suspend and resume commands

### DIFF
--- a/snowclaw/cli.py
+++ b/snowclaw/cli.py
@@ -13,8 +13,10 @@ from snowclaw.commands import (
     cmd_network,
     cmd_pull,
     cmd_push,
+    cmd_resume,
     cmd_setup,
     cmd_status,
+    cmd_suspend,
     cmd_update,
 )
 
@@ -34,6 +36,8 @@ def build_parser() -> argparse.ArgumentParser:
     build_parser.add_argument("--tag", default="latest", help="Docker image tag (default: latest)")
     sub.add_parser("deploy", help="Build, push, and deploy to SPCS")
     sub.add_parser("status", help="Show deployed service status, endpoints, and compute pool")
+    sub.add_parser("suspend", help="Suspend the SPCS service and compute pool")
+    sub.add_parser("resume", help="Resume the SPCS compute pool and service")
     sub.add_parser("update", help="Update the OpenClaw version")
 
     pull_parser = sub.add_parser("pull", help="Pull skills and workspace from SPCS stage")
@@ -92,6 +96,8 @@ def main():
         "build": cmd_build,
         "deploy": cmd_deploy,
         "status": cmd_status,
+        "suspend": cmd_suspend,
+        "resume": cmd_resume,
         "update": cmd_update,
         "pull": cmd_pull,
         "push": cmd_push,

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -981,6 +981,110 @@ def cmd_status(args: argparse.Namespace):
     console.print()
 
 
+def cmd_suspend(args: argparse.Namespace):
+    """Suspend the SPCS service and compute pool."""
+    render_banner()
+    root = find_project_root()
+    ctx = load_snowflake_context(root)
+
+    account = ctx["account"]
+    token = ctx["token"]
+    names = ctx["names"]
+
+    if not account or not token:
+        console.print("[red]Missing Snowflake credentials in .env.[/red]")
+        console.print("Required: SNOWFLAKE_ACCOUNT, SNOWFLAKE_TOKEN")
+        sys.exit(1)
+
+    db = names["db"]
+    schema_name = names["schema_name"]
+    fqn_schema = names["schema"]
+    warehouse = ctx["warehouse"]
+    service_name = names["service"]
+    pool_name = names["pool"]
+
+    # Suspend service first (required before suspending compute pool)
+    console.print(f"[bold]Suspending service {service_name}...[/bold]")
+    try:
+        snowflake_rest_execute(
+            account, token,
+            f"ALTER SERVICE {fqn_schema}.{service_name} SUSPEND",
+            database=db, schema=schema_name, warehouse=warehouse,
+        )
+        console.print(f"  [green]✓[/green] Service suspended")
+    except requests.HTTPError as e:
+        console.print(f"  [red]✗[/red] Failed to suspend service: {e}")
+        sys.exit(1)
+
+    # Suspend compute pool
+    console.print(f"[bold]Suspending compute pool {pool_name}...[/bold]")
+    try:
+        snowflake_rest_execute(
+            account, token,
+            f"ALTER COMPUTE POOL {pool_name} SUSPEND",
+            database=db, schema=schema_name, warehouse=warehouse,
+        )
+        console.print(f"  [green]✓[/green] Compute pool suspended")
+    except requests.HTTPError as e:
+        console.print(f"  [red]✗[/red] Failed to suspend compute pool: {e}")
+        sys.exit(1)
+
+    console.print()
+    console.print("[green]Suspend complete.[/green]")
+
+
+def cmd_resume(args: argparse.Namespace):
+    """Resume the SPCS compute pool and service."""
+    render_banner()
+    root = find_project_root()
+    ctx = load_snowflake_context(root)
+
+    account = ctx["account"]
+    token = ctx["token"]
+    names = ctx["names"]
+
+    if not account or not token:
+        console.print("[red]Missing Snowflake credentials in .env.[/red]")
+        console.print("Required: SNOWFLAKE_ACCOUNT, SNOWFLAKE_TOKEN")
+        sys.exit(1)
+
+    db = names["db"]
+    schema_name = names["schema_name"]
+    fqn_schema = names["schema"]
+    warehouse = ctx["warehouse"]
+    service_name = names["service"]
+    pool_name = names["pool"]
+
+    # Resume compute pool first (required before resuming service)
+    console.print(f"[bold]Resuming compute pool {pool_name}...[/bold]")
+    try:
+        snowflake_rest_execute(
+            account, token,
+            f"ALTER COMPUTE POOL {pool_name} RESUME",
+            database=db, schema=schema_name, warehouse=warehouse,
+        )
+        console.print(f"  [green]✓[/green] Compute pool resumed")
+    except requests.HTTPError as e:
+        console.print(f"  [red]✗[/red] Failed to resume compute pool: {e}")
+        sys.exit(1)
+
+    # Resume service
+    console.print(f"[bold]Resuming service {service_name}...[/bold]")
+    try:
+        snowflake_rest_execute(
+            account, token,
+            f"ALTER SERVICE {fqn_schema}.{service_name} RESUME",
+            database=db, schema=schema_name, warehouse=warehouse,
+        )
+        console.print(f"  [green]✓[/green] Service resumed")
+    except requests.HTTPError as e:
+        console.print(f"  [red]✗[/red] Failed to resume service: {e}")
+        sys.exit(1)
+
+    console.print()
+    console.print("[green]Resume complete.[/green]")
+
+
 def cmd_channel(args: argparse.Namespace):
     """Manage communication channel configurations."""
     sub = getattr(args, "channel_command", None)


### PR DESCRIPTION
Adds `snowclaw suspend` and `snowclaw resume` commands for managing SPCS service and compute pool lifecycle.

- **suspend**: suspends service first, then compute pool (correct order)
- **resume**: resumes compute pool first, then service (correct order)
- Graceful error handling — if the first step fails, skips the second

Depends on #24