### PR TITLE
feat: admin/service role separation for least-privilege security

### DIFF
--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -159,7 +159,23 @@ def cmd_setup(args: argparse.Namespace):
             tool_credentials[cred["env_var"]] = value.strip()
 
     warehouse = inquirer.text(message="Snowflake warehouse:", default="COMPUTE_WH").execute()
-    role = inquirer.text(message="Snowflake role:", default="SYSADMIN").execute()
+
+    console.print()
+    console.print(Panel(
+        "[bold]SnowClaw uses two Snowflake roles:[/bold]\n\n"
+        "  [cyan]Admin role[/cyan] — Used by the CLI for infrastructure management\n"
+        "  (creating services, compute pools, network rules, secrets).\n\n"
+        "  [cyan]Service role[/cyan] — Used by OpenClaw at runtime inside the container.\n"
+        "  Should have minimal permissions: query execution, Cortex access, stage reads.\n"
+        "  This role must already exist in your Snowflake account.",
+        title="Role Configuration",
+        border_style="cyan",
+        expand=False,
+    ))
+
+    admin_role = inquirer.text(message="Admin role:", default="SYSADMIN").execute()
+    service_role = inquirer.text(message="Service role:", default="SNOWCLAW_SERVICE_ROLE").execute()
+
     database = inquirer.text(
         message="Snowflake database name:",
         default="snowclaw_db",
@@ -179,7 +195,8 @@ def cmd_setup(args: argparse.Namespace):
         "pat": pat.strip(),
         "channels": channels,
         "warehouse": warehouse.strip(),
-        "role": role.strip(),
+        "admin_role": admin_role.strip(),
+        "service_role": service_role.strip(),
         "database": database,
         "schema": schema,
         **channel_creds,
@@ -193,6 +210,8 @@ def cmd_setup(args: argparse.Namespace):
         "created": datetime.now(timezone.utc).isoformat(),
         "database": database,
         "schema": schema,
+        "admin_role": admin_role.strip(),
+        "service_role": service_role.strip(),
         "openclaw_version": "latest",
         "tools": tools,
     }

--- a/snowclaw/config.py
+++ b/snowclaw/config.py
@@ -18,6 +18,8 @@ def write_dotenv(root: Path, settings: dict):
         f"SNOWFLAKE_ACCOUNT={settings['account']}",
         f"SNOWFLAKE_USER={settings['sf_user']}",
         f"SNOWFLAKE_TOKEN={settings['pat']}",
+        f"SNOWCLAW_ADMIN_ROLE={settings.get('admin_role', 'SYSADMIN')}",
+        f"SNOWCLAW_SERVICE_ROLE={settings.get('service_role', 'SNOWCLAW_SERVICE_ROLE')}",
     ]
     # Write env vars for all enabled channels
     for ch_key in settings.get("channels", []):
@@ -135,7 +137,7 @@ user = "{settings['sf_user']}"
 authenticator = "PROGRAMMATIC_ACCESS_TOKEN"
 token = "{settings['pat']}"
 warehouse = "{settings.get('warehouse', 'COMPUTE_WH')}"
-role = "{settings.get('role', 'SYSADMIN')}"
+role = "{settings.get('admin_role', 'SYSADMIN')}"
 """
     conn_path = root / "connections.toml"
     conn_path.write_text(content)

--- a/snowclaw/scaffold.py
+++ b/snowclaw/scaffold.py
@@ -164,6 +164,8 @@ def assemble_build_context(root: Path) -> Path:
             f"          envVarName: {sec['env_var']}\n"
         )
 
+    service_role = marker.get("service_role", "SNOWCLAW_SERVICE_ROLE")
+
     for name in ("service.yaml", "image-repo.sql"):
         src = templates / "spcs" / name
         if src.exists():
@@ -173,6 +175,7 @@ def assemble_build_context(root: Path) -> Path:
             content = content.replace("__SNOWCLAW_PREFIX__", prefix)
             if name == "service.yaml":
                 content = content.replace("__CHANNEL_SECRETS__", channel_secrets_yaml)
+                content = content.replace("__SNOWCLAW_SERVICE_ROLE__", service_role)
             (spcs_dir / name).write_text(content)
 
     # Generate network-rules.sql from saved rules

--- a/snowclaw/utils.py
+++ b/snowclaw/utils.py
@@ -167,6 +167,15 @@ def load_snowflake_context(root: Path) -> dict:
     token = env.get("SNOWFLAKE_TOKEN")
     sf_user = env.get("SNOWFLAKE_USER")
     warehouse = env.get("SNOWFLAKE_WAREHOUSE") or conn.get("warehouse")
+    admin_role = (
+        env.get("SNOWCLAW_ADMIN_ROLE")
+        or conn.get("role")
+        or marker.get("admin_role", "SYSADMIN")
+    )
+    service_role = (
+        env.get("SNOWCLAW_SERVICE_ROLE")
+        or marker.get("service_role", "SNOWCLAW_SERVICE_ROLE")
+    )
 
     return {
         "account": account,
@@ -175,6 +184,8 @@ def load_snowflake_context(root: Path) -> dict:
         "database": database,
         "schema": schema,
         "warehouse": warehouse,
+        "admin_role": admin_role,
+        "service_role": service_role,
         "names": names,
         "env": env,
         "conn": conn,

--- a/templates/spcs/service.yaml
+++ b/templates/spcs/service.yaml
@@ -13,6 +13,8 @@ __CHANNEL_SECRETS__
         - snowflakeSecret: __SNOWCLAW_DB__.__SNOWCLAW_SCHEMA__.__SNOWCLAW_PREFIX___brave_api_key
           secretKeyRef: secret_string
           envVarName: BRAVE_API_KEY
+      env:
+        SNOWFLAKE_ROLE: __SNOWCLAW_SERVICE_ROLE__
       resources:
         requests:
           cpu: 1


### PR DESCRIPTION
Separates the single Snowflake role into two:

- **Admin role** (default: SYSADMIN) — used by CLI for infrastructure management
- **Service role** (default: SNOWCLAW_SERVICE_ROLE) — used by OpenClaw at runtime in the container

Setup wizard includes a Role Configuration panel explaining both roles. The service role must already exist in the user's Snowflake account — SnowClaw does not create or manage role permissions.

Service role is passed to the container via `SNOWFLAKE_ROLE` env var in the SPCS service spec.

Depends on #25