### PR TITLE
docs: update README with current features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # SnowClaw
 
-Run [OpenClaw](https://github.com/openclaw/openclaw) on [Snowflake Container Services](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview) with zero forking. SnowClaw is a CLI that scaffolds, configures, and deploys a fully-wired OpenClaw instance — complete with Snowflake-native LLM providers, Slack integration, and Cortex Code — in minutes.
+Run [OpenClaw](https://github.com/openclaw/openclaw) on [Snowflake Container Services](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview) with zero forking. SnowClaw is a CLI that scaffolds, configures, and deploys a fully-wired OpenClaw instance — complete with Snowflake Cortex LLMs, multi-channel messaging, and a Cortex-compatible proxy — in minutes.
 
 ## Features
 
-- **One-command setup** — Interactive wizard collects credentials, generates config, and optionally provisions all Snowflake objects (database, image repo, compute pool, secrets) via REST API. No snowsql required.
-- **Dynamic network rules** — Auto-detects required external hosts from your config (providers, Slack) and prompts for approval before creating Snowflake network rules. Add custom hosts on the fly with `snowclaw network add`.
-- **Snowflake Cortex LLMs** — Pre-configured as a provider. Models run inside Snowflake with no data leaving your account.
-- **Slack integration** — Socket mode out of the box — no public webhook URL needed, which is ideal for SPCS.
-- **Cortex Code** — Installed automatically in the container image, with a bundled skill definition for immediate use.
-- **Local dev mode** — `snowclaw dev` builds and runs everything locally with Docker Compose for fast iteration.
+- **One-command setup** — Interactive wizard collects credentials, generates config, and optionally provisions all Snowflake objects via REST API. No snowsql required.
+- **Snowflake Cortex LLMs** — Pre-configured as a provider. Models run inside Snowflake — your data never leaves your account.
+- **Cortex proxy sidecar** — A FastAPI proxy sits between OpenClaw and Cortex, fixing parallel tool call issues for Claude models and normalizing request parameters across model families. Also masks secrets in outbound LLM traffic so credentials never reach the model.
+- **Multi-channel messaging** — Slack, Telegram, and Discord supported out of the box. `snowclaw channel add` walks you through configuration with auto-detected network rules per channel.
+- **Dynamic network rules** — Auto-detects required external hosts from your config and prompts for approval before creating Snowflake network rules and external access integrations.
+- **Config lockdown** — Sensitive files (`openclaw.json`, credentials) are root-owned and read-only at runtime. The agent can read config but cannot modify it. Defense-in-depth via `workspaceOnly` tool policy.
+- **Admin/service role separation** — CLI operations use your admin role; the deployed container runs under a least-privilege service role.
+- **Build hooks** — Drop `.sh` scripts into `build-hooks/` to install packages or tools at image build time. No Dockerfile editing needed.
+- **User-managed secrets** — Add `CUSTOM_`-prefixed vars to `.env` and they become individual Snowflake secrets, mounted into the container, and auto-masked by the proxy.
+- **Cortex Code** — Installed automatically in the container image with a bundled skill definition.
+- **Local dev mode** — `snowclaw dev` builds and runs everything locally with Docker Compose.
 - **SPCS deployment** — `snowclaw deploy` builds the image, pushes to your Snowflake registry, and creates/updates the service in one step.
-- **Workspace sync** — `snowclaw push` and `snowclaw pull` sync your local skills and workspace files to/from SPCS stage storage.
-- **No fork needed** — Builds on the official OpenClaw image. Your config, skills, and plugins are layered on top at build time.
+- **Config and workspace sync** — `snowclaw push` and `snowclaw pull` sync skills, workspace, and `openclaw.json` to/from SPCS stage storage — no rebuild required.
 - **Persistent state** — SPCS stage-backed volume keeps conversations, skills, and workspace data across container restarts.
+- **No fork needed** — Builds on the official OpenClaw image. Your config, skills, and plugins are layered on top.
 
 ## Prerequisites
 
@@ -45,7 +50,8 @@ snowclaw dev
 
 The setup wizard will prompt for:
 - Snowflake account, username, and PAT token
-- Slack bot and app tokens (optional)
+- Admin and service roles
+- Communication channels (Slack, Telegram, Discord)
 - Whether to create Snowflake objects (database, compute pool, etc.)
 
 Once complete, open `http://localhost:18789` to access the OpenClaw UI.
@@ -59,22 +65,29 @@ Once complete, open `http://localhost:18789` to access the OpenClaw UI.
 | `snowclaw dev` | Build and run locally with Docker Compose |
 | `snowclaw build` | Build the Docker image without deploying |
 | `snowclaw deploy` | Build, push to Snowflake registry, and create/update the SPCS service |
+| `snowclaw status` | Show service status, endpoints, and compute pool state |
+| `snowclaw suspend` | Suspend the SPCS service and compute pool |
+| `snowclaw resume` | Resume the SPCS compute pool and service |
+| `snowclaw restart` | Restart the service to pick up config changes |
+| `snowclaw logs` | Show container logs from the SPCS service |
 | `snowclaw update` | Update the OpenClaw base image version |
-| `snowclaw pull` | Pull skills and workspace from SPCS stage to local |
-| `snowclaw push` | Push local skills and workspace to SPCS stage |
+| `snowclaw push` | Push skills, workspace, and config to SPCS stage |
+| `snowclaw pull` | Pull skills, workspace, and config from SPCS stage |
 | `snowclaw network list` | Show current approved network rules |
-| `snowclaw network add <host>` | Add a network rule (prompts to apply to Snowflake) |
+| `snowclaw network add <host>` | Add a network rule (prompts to apply) |
 | `snowclaw network remove <host>` | Remove a network rule |
 | `snowclaw network detect` | Auto-detect required rules from project config |
 | `snowclaw network apply` | Push current rules to Snowflake |
+| `snowclaw channel list` | Show configured channels |
+| `snowclaw channel add` | Interactive wizard to add a channel |
+| `snowclaw channel edit <name>` | Edit a channel's credentials |
+| `snowclaw channel remove <name>` | Remove a channel |
 
-`snowclaw pull` and `snowclaw push` accept `--workspace-only` or `--skills-only` to sync selectively.
-
-`snowclaw network add` accepts `host` or `host:port` (default port 443) and an optional `--reason` flag.
+`push` and `pull` accept `--workspace-only`, `--skills-only`, or `--config-only` to sync selectively.
 
 ## Project Structure
 
-After running `snowclaw setup`, your project directory looks like this:
+After running `snowclaw setup`:
 
 ```
 my-openclaw/
@@ -87,74 +100,39 @@ my-openclaw/
   connections.toml        # Snowflake connection — gitignored
   skills/                 # Editable skill definitions
     cortex-code/
+  build-hooks/            # Custom build scripts (*.sh, run at image build time)
   workspace/              # Markdown knowledge base
 ```
 
-Edit `openclaw.json` to add agents, change model routing, or configure channels. Add markdown files to `workspace/` to give your agents reference material. Skills in `skills/` are synced into the container at build time.
+## Security
 
-## Model Providers
+SnowClaw applies multiple layers of protection in the deployed container:
 
-**Snowflake Cortex** is always enabled. It uses your Snowflake account credentials to call Cortex LLMs — your data stays within Snowflake.
-
-## Network Rules
-
-Snowflake Container Services blocks all outbound traffic by default. SnowClaw manages network rules dynamically so your service can reach external APIs.
-
-**During setup**, the CLI auto-detects which hosts are required based on your config (e.g., Slack WebSocket endpoints if Slack is enabled, `*.snowflakecomputing.com:443` for Cortex) and prompts you to approve them before creating the Snowflake objects.
-
-**During deploy**, the CLI re-checks your config against saved rules and prompts for approval if anything changed (e.g., you added a new provider).
-
-**Manual management** is available for hosts the CLI can't auto-detect:
-
-```bash
-# Add a custom API endpoint
-snowclaw network add api.example.com --reason "Custom API"
-
-# Add with a non-standard port
-snowclaw network add db.example.com:5432 --reason "External database"
-
-# View current rules
-snowclaw network list
-
-# Remove a rule
-snowclaw network remove api.example.com
-
-# Push current rules to Snowflake
-snowclaw network apply
-```
-
-Rules are saved in `.snowclaw/network-rules.json` (committed to git) and compiled into a single Snowflake `NETWORK RULE` + `EXTERNAL ACCESS INTEGRATION` when applied.
-
-## Deploying to SPCS
-
-```bash
-snowclaw deploy
-```
-
-This will:
-1. Assemble the build context (Dockerfile, config, plugins, skills)
-2. Build the Docker image
-3. Push it to your Snowflake image repository
-4. Create or update the SPCS service
-
-The service runs on a `CPU_X64_S` compute pool with 1-2 CPUs and 2-4 GiB RAM. State is persisted to an internal stage mounted as a volume.
-
-After deployment, use `snowclaw push` and `snowclaw pull` to sync skills and workspace content without rebuilding.
+- **File permissions** — `openclaw.json` and credential files are owned by root with read-only access for the gateway process. The agent cannot modify config at runtime.
+- **Tool policy** — `workspaceOnly` restricts native file tools to the workspace directory.
+- **Role separation** — The CLI uses your admin role for infrastructure. The container runs under a dedicated service role with minimal privileges.
+- **Secret masking** — The Cortex proxy scans all outbound LLM messages and replaces known secret values with `[REDACTED:VAR_NAME]`.
+- **User secrets** — `CUSTOM_`-prefixed env vars in `.env` become individual Snowflake secrets, mounted at runtime (never baked into the image).
 
 ## Architecture
 
 ```
-Slack <--socket--> SPCS Ingress <--> OpenClaw Gateway (:18789)
-                                       |
-                                       +-- Web UI
-                                       +-- WebSocket RPC
-                                       +-- /v1/* OpenAI-compatible API
-                                       +-- Plugin HTTP routes
-                                       |
-                                       +-- Snowflake Cortex (outbound)
+Channels <--socket/ws--> SPCS Ingress <--> OpenClaw Gateway (:18789)
+                                             |
+                                             +-- Web UI
+                                             +-- WebSocket RPC
+                                             +-- /v1/* OpenAI-compatible API
+                                             +-- Plugin HTTP routes
+                                             |
+                                           Cortex Proxy Sidecar (:8080)
+                                             +-- Parallel tool call serialization
+                                             +-- Secret masking
+                                             +-- Request normalization
+                                             |
+                                             +-- Snowflake Cortex (outbound)
 ```
 
-All traffic goes through a single SPCS ingress endpoint on port 18789. Snowflake handles TLS and authentication.
+All traffic goes through a single SPCS ingress endpoint on port 18789. The Cortex proxy runs as a sidecar container in the same service. Snowflake handles TLS and authentication.
 
 ## License
 


### PR DESCRIPTION
Updates README.md to reflect recent feature additions and simplifies content for clarity.

## Changes
- Added: Cortex proxy sidecar, build hooks, user-managed secrets, config lockdown, role separation, multi-channel messaging, suspend/resume/restart/status/logs commands, config sync
- Added: Security section covering file permissions, tool policy, role separation, secret masking
- Updated: Architecture diagram to show proxy sidecar
- Updated: CLI commands table with all current commands (channel, status, suspend, resume, restart, logs)
- Updated: Project structure to include build-hooks/
- Simplified: Removed verbose network rules section, condensed feature descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)