### PR TITLE
fix: use $PY -m pipx instead of bare pipx in install scripts

### DIFF
--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -38,7 +38,7 @@ fi
 
 # --- Editable install with dev extras ---
 info "Installing snowclaw (editable + dev deps)..."
-pipx install --force -e ".[dev]"
+$PY -m pipx install --force -e ".[dev]"
 
 # --- Verify ---
 if ! command -v snowclaw &>/dev/null; then
@@ -48,8 +48,8 @@ fi
 info "Installed snowclaw $(snowclaw --version 2>/dev/null || echo '(version unknown)')"
 
 # Check pytest is available via pipx runpip
-if pipx runpip snowclaw show pytest &>/dev/null; then
-    info "pytest available — run tests with: pipx run --spec . pytest"
+if $PY -m pipx runpip snowclaw show pytest &>/dev/null; then
+    info "pytest available — run tests with: $PY -m pipx run --spec . pytest"
 else
     info "Warning: pytest not found in the snowclaw venv"
 fi

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ if ! command -v pipx &>/dev/null; then
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
-info "Using pipx at $(command -v pipx)"
+info "Using pipx via: $PY -m pipx"
 
 # --- Clone or update repo ---
 if [ -d "$INSTALL_DIR/.git" ]; then
@@ -52,7 +52,7 @@ fi
 
 # --- Install CLI from local checkout ---
 info "Installing snowclaw CLI..."
-pipx install --force -e "$INSTALL_DIR"
+$PY -m pipx install --force -e "$INSTALL_DIR"
 
 # --- Verify ---
 if command -v snowclaw &>/dev/null; then


### PR DESCRIPTION
Bare pipx may not be on PATH immediately after pip install. Running as a Python module works regardless.