### PR TITLE
docs: reorg README and expand security section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,26 @@ This installs SnowClaw in editable mode via pipx with dev dependencies (pytest).
 pipx run --spec . pytest
 ```
 
-## Project Layout
+## Project Structure
+
+After running `snowclaw setup`:
+
+```
+my-openclaw/
+  .snowclaw/              # Project marker and build artifacts
+    config.json           # Project metadata (version, prefix, etc.)
+    network-rules.json    # Approved network rules for external access
+  .env                    # Secrets — gitignored
+  .gitignore
+  openclaw.json           # OpenClaw configuration (providers, channels, agents)
+  connections.toml        # Snowflake connection — gitignored
+  skills/                 # Editable skill definitions
+    cortex-code/
+  build-hooks/            # Custom build scripts (*.sh, run at image build time)
+  workspace/              # Markdown knowledge base
+```
+
+## Project Layout (repo)
 
 - `snowclaw/` — CLI Python package (editable install means changes are live)
 - `templates/` — Build-time templates (Dockerfile, SPCS specs, plugins, scripts)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,6 @@
 # SnowClaw
 
-Run [OpenClaw](https://github.com/openclaw/openclaw) on [Snowflake Container Services](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview) with zero forking. SnowClaw is a CLI that scaffolds, configures, and deploys a fully-wired OpenClaw instance — complete with Snowflake Cortex LLMs, multi-channel messaging, and a Cortex-compatible proxy — in minutes.
-
-## Features
-
-- **One-command setup** — Interactive wizard collects credentials, generates config, and optionally provisions all Snowflake objects via REST API. No snowsql required.
-- **Snowflake Cortex LLMs** — Pre-configured as a provider. Models run inside Snowflake — your data never leaves your account.
-- **Cortex proxy sidecar** — A FastAPI proxy sits between OpenClaw and Cortex, fixing parallel tool call issues for Claude models and normalizing request parameters across model families. Also masks secrets in outbound LLM traffic so credentials never reach the model.
-- **Multi-channel messaging** — Slack, Telegram, and Discord supported out of the box. `snowclaw channel add` walks you through configuration with auto-detected network rules per channel.
-- **Dynamic network rules** — Auto-detects required external hosts from your config and prompts for approval before creating Snowflake network rules and external access integrations.
-- **Config lockdown** — Sensitive files (`openclaw.json`, credentials) are root-owned and read-only at runtime. The agent can read config but cannot modify it. Defense-in-depth via `workspaceOnly` tool policy.
-- **Admin/service role separation** — CLI operations use your admin role; the deployed container runs under a least-privilege service role.
-- **Build hooks** — Drop `.sh` scripts into `build-hooks/` to install packages or tools at image build time. No Dockerfile editing needed.
-- **User-managed secrets** — Add `CUSTOM_`-prefixed vars to `.env` and they become individual Snowflake secrets, mounted into the container, and auto-masked by the proxy.
-- **Cortex Code** — Installed automatically in the container image with a bundled skill definition.
-- **Local dev mode** — `snowclaw dev` builds and runs everything locally with Docker Compose.
-- **SPCS deployment** — `snowclaw deploy` builds the image, pushes to your Snowflake registry, and creates/updates the service in one step.
-- **Config and workspace sync** — `snowclaw push` and `snowclaw pull` sync skills, workspace, and `openclaw.json` to/from SPCS stage storage — no rebuild required.
-- **Persistent state** — SPCS stage-backed volume keeps conversations, skills, and workspace data across container restarts.
-- **No fork needed** — Builds on the official OpenClaw image. Your config, skills, and plugins are layered on top.
+Run [OpenClaw](https://github.com/openclaw/openclaw) on [Snowflake Container Services](https://docs.snowflake.com/en/developer-guide/snowpark-container-services/overview). SnowClaw is a CLI that scaffolds, configures, and deploys a fully-wired OpenClaw instance on SPCS in minutes.
 
 ## Prerequisites
 
@@ -48,13 +30,50 @@ snowclaw setup
 snowclaw dev
 ```
 
-The setup wizard will prompt for:
-- Snowflake account, username, and PAT token
-- Admin and service roles
-- Communication channels (Slack, Telegram, Discord)
-- Whether to create Snowflake objects (database, compute pool, etc.)
+The setup wizard prompts for your Snowflake account, credentials, roles, communication channels, and optionally provisions all Snowflake objects via REST API. Once complete, open `http://localhost:18789` for the OpenClaw UI.
 
-Once complete, open `http://localhost:18789` to access the OpenClaw UI.
+## Security
+
+SnowClaw is designed to be safe to run in your Snowflake account by default.
+
+- **Network egress control** — All outbound traffic is deny-by-default. Only explicitly approved hosts (managed via `snowclaw network`) get Snowflake network rules and external access integrations. The container cannot reach the internet unless you allow it.
+- **SPCS ingress control** — Snowflake handles TLS termination and authentication on the single public endpoint. There are no open ports or exposed services beyond what SPCS declares — the ingress surface is managed entirely by Snowflake's infrastructure.
+- **File permissions** — `openclaw.json` and credential files are root-owned and read-only at runtime. The agent cannot modify config.
+- **Tool policy** — `workspaceOnly` restricts native file tools to the workspace directory.
+- **Role separation** — The CLI uses your admin role for infrastructure operations. The deployed container runs under a dedicated service role with minimal privileges.
+- **Secret masking** — The Cortex proxy scans all outbound LLM messages and replaces known secret values with `[REDACTED:VAR_NAME]`. Credentials never reach the model.
+- **User-managed secrets** — `CUSTOM_`-prefixed env vars in `.env` become individual Snowflake secrets, mounted at runtime — never baked into the image.
+
+## Features
+
+- **One-command setup** — Interactive wizard collects credentials, generates config, and optionally provisions all Snowflake objects via REST API. No snowsql required.
+- **Snowflake Cortex LLMs** — Pre-configured as a provider. Models run inside Snowflake — your data never leaves your account.
+- **Cortex Code** — AI coding assistant installed automatically in the container with a bundled skill definition. Your agent can write, edit, and manage code out of the box.
+- **Cortex proxy sidecar** — A FastAPI proxy between OpenClaw and Cortex that serializes parallel tool calls (fixing Claude model issues), normalizes request parameters across model families, and masks secrets in outbound traffic.
+- **Multi-channel messaging** — Slack, Telegram, and Discord supported out of the box. `snowclaw channel add` walks you through configuration with auto-detected network rules per channel.
+- **Dynamic network rules** — Auto-detects required external hosts from your config and prompts for approval before creating Snowflake network rules and external access integrations.
+- **Build hooks** — Drop `.sh` scripts into `build-hooks/` to install packages or tools at image build time. No Dockerfile editing needed.
+- **Local dev and SPCS deployment** — `snowclaw dev` runs everything locally with Docker Compose. `snowclaw deploy` builds, pushes, and creates the SPCS service in one step. `snowclaw push` and `snowclaw pull` sync config and workspace without rebuilding.
+
+## Architecture
+
+```
+Channels <--socket/ws--> SPCS Ingress <--> OpenClaw Gateway (:18789)
+                                             |
+                                             +-- Web UI
+                                             +-- WebSocket RPC
+                                             +-- /v1/* OpenAI-compatible API
+                                             +-- Plugin HTTP routes
+                                             |
+                                           Cortex Proxy Sidecar (:8080)
+                                             +-- Parallel tool call serialization
+                                             +-- Secret masking
+                                             +-- Request normalization
+                                             |
+                                             +-- Snowflake Cortex (outbound)
+```
+
+All traffic goes through a single SPCS ingress endpoint on port 18789. The Cortex proxy runs as a sidecar container in the same service. Snowflake handles TLS and authentication.
 
 ## CLI Commands
 
@@ -84,55 +103,6 @@ Once complete, open `http://localhost:18789` to access the OpenClaw UI.
 | `snowclaw channel remove <name>` | Remove a channel |
 
 `push` and `pull` accept `--workspace-only`, `--skills-only`, or `--config-only` to sync selectively.
-
-## Project Structure
-
-After running `snowclaw setup`:
-
-```
-my-openclaw/
-  .snowclaw/              # Project marker and build artifacts
-    config.json           # Project metadata (version, prefix, etc.)
-    network-rules.json    # Approved network rules for external access
-  .env                    # Secrets — gitignored
-  .gitignore
-  openclaw.json           # OpenClaw configuration (providers, channels, agents)
-  connections.toml        # Snowflake connection — gitignored
-  skills/                 # Editable skill definitions
-    cortex-code/
-  build-hooks/            # Custom build scripts (*.sh, run at image build time)
-  workspace/              # Markdown knowledge base
-```
-
-## Security
-
-SnowClaw applies multiple layers of protection in the deployed container:
-
-- **File permissions** — `openclaw.json` and credential files are owned by root with read-only access for the gateway process. The agent cannot modify config at runtime.
-- **Tool policy** — `workspaceOnly` restricts native file tools to the workspace directory.
-- **Role separation** — The CLI uses your admin role for infrastructure. The container runs under a dedicated service role with minimal privileges.
-- **Secret masking** — The Cortex proxy scans all outbound LLM messages and replaces known secret values with `[REDACTED:VAR_NAME]`.
-- **User secrets** — `CUSTOM_`-prefixed env vars in `.env` become individual Snowflake secrets, mounted at runtime (never baked into the image).
-
-## Architecture
-
-```
-Channels <--socket/ws--> SPCS Ingress <--> OpenClaw Gateway (:18789)
-                                             |
-                                             +-- Web UI
-                                             +-- WebSocket RPC
-                                             +-- /v1/* OpenAI-compatible API
-                                             +-- Plugin HTTP routes
-                                             |
-                                           Cortex Proxy Sidecar (:8080)
-                                             +-- Parallel tool call serialization
-                                             +-- Secret masking
-                                             +-- Request normalization
-                                             |
-                                             +-- Snowflake Cortex (outbound)
-```
-
-All traffic goes through a single SPCS ingress endpoint on port 18789. The Cortex proxy runs as a sidecar container in the same service. Snowflake handles TLS and authentication.
 
 ## License
 


### PR DESCRIPTION
- Reordered: Prerequisites → Installation → Quick Start → Security → Features → Architecture → CLI Commands
- Expanded Security with network egress control (deny-by-default) and SPCS ingress controls
- Trimmed Features from 14 to 8 bullets (moved security items to Security section, removed redundant items)
- Moved Project Structure to CONTRIBUTING.md
- Cortex Code highlighted as key feature