### PR TITLE
fix: lowercase db/schema in Docker image repo path

### DIFF
--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -380,7 +380,7 @@ def cmd_deploy(args: argparse.Namespace):
     warehouse = ctx["warehouse"]
     repo = names["repo"]
     registry_host = f"{account}.registry.snowflakecomputing.com"
-    image_repo = f"{registry_host}/{db}/{schema_name}/{repo}"
+    image_repo = f"{registry_host}/{db}/{schema_name}/{repo}".lower()
 
     # Check network rules before deploying
     console.print("[bold]Checking network rules...[/bold]")


### PR DESCRIPTION
Docker image names must be lowercase. Snowflake database and schema names can be mixed-case (e.g. `SNOWCLAW_DB`, `PUBLIC`), which causes `docker push` to fail when those names appear in the image path.

Applies `.lower()` to the full `image_repo` string so names like:
`MYACCOUNT.registry.snowflakecomputing.com/SNOWCLAW_DB/PUBLIC/snowclaw_repo`

become:
`myaccount.registry.snowflakecomputing.com/snowclaw_db/public/snowclaw_repo`

One-line fix in `cmd_deploy()`.