### PR TITLE
fix: build Docker images for linux/amd64 platform

### DIFF
--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -336,7 +336,7 @@ def cmd_build(args: argparse.Namespace):
 
     console.print("[bold]Building proxy image...[/bold]")
     result = subprocess.run(
-        ["docker", "build", "-t", f"snowclaw-proxy:{image_tag}", str(build_dir / "proxy")],
+        ["docker", "build", "--platform", "linux/amd64", "-t", f"snowclaw-proxy:{image_tag}", str(build_dir / "proxy")],
     )
     if result.returncode != 0:
         console.print("[red]Proxy build failed.[/red]")
@@ -346,7 +346,7 @@ def cmd_build(args: argparse.Namespace):
     console.print()
     console.print("[bold]Building Docker image...[/bold]")
     result = subprocess.run(
-        ["docker", "build", "-t", f"snowclaw:{image_tag}", str(build_dir)],
+        ["docker", "build", "--platform", "linux/amd64", "-t", f"snowclaw:{image_tag}", str(build_dir)],
     )
     if result.returncode != 0:
         console.print("[red]Build failed.[/red]")
@@ -442,7 +442,7 @@ def cmd_deploy(args: argparse.Namespace):
     console.print()
     console.print("[bold]Building proxy image...[/bold]")
     result = subprocess.run(
-        ["docker", "build", "-t", f"snowclaw-proxy:{image_tag}", str(build_dir / "proxy")],
+        ["docker", "build", "--platform", "linux/amd64", "-t", f"snowclaw-proxy:{image_tag}", str(build_dir / "proxy")],
     )
     if result.returncode != 0:
         console.print("[red]Proxy build failed.[/red]")
@@ -453,7 +453,7 @@ def cmd_deploy(args: argparse.Namespace):
     console.print()
     console.print("[bold]Building Docker image...[/bold]")
     result = subprocess.run(
-        ["docker", "build", "-t", f"snowclaw:{image_tag}", str(build_dir)],
+        ["docker", "build", "--platform", "linux/amd64", "-t", f"snowclaw:{image_tag}", str(build_dir)],
     )
     if result.returncode != 0:
         console.print("[red]Build failed.[/red]")


### PR DESCRIPTION
SPCS runs on amd64. Without `--platform`, Docker builds for the host architecture (e.g. arm64 on Apple Silicon), producing images that fail on SPCS.

Adds `--platform linux/amd64` to all four `docker build` commands in `cmd_build` and `cmd_deploy`.