### PR TITLE
Backfill maxTokens default in openclaw.json migration

### DIFF
--- a/snowclaw/config.py
+++ b/snowclaw/config.py
@@ -8,13 +8,15 @@ from pathlib import Path
 from snowclaw.network import CHANNEL_REGISTRY, TOOL_REGISTRY
 from snowclaw.utils import console
 
+DEFAULT_MAX_TOKENS = 131072
+
 CORTEX_CLAUDE_MODELS = [
-    {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "contextWindow": 200000, "maxTokens": 131072},
-    {"id": "claude-opus-4-6", "name": "Claude Opus 4.6", "contextWindow": 200000, "maxTokens": 131072},
+    {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "contextWindow": 200000, "maxTokens": DEFAULT_MAX_TOKENS},
+    {"id": "claude-opus-4-6", "name": "Claude Opus 4.6", "contextWindow": 200000, "maxTokens": DEFAULT_MAX_TOKENS},
 ]
 
 CORTEX_OPENAI_MODELS = [
-    {"id": "openai-gpt-5.1", "name": "GPT-5.1", "contextWindow": 1047576, "maxTokens": 131072},
+    {"id": "openai-gpt-5.1", "name": "GPT-5.1", "contextWindow": 1047576, "maxTokens": DEFAULT_MAX_TOKENS},
 ]
 
 # Combined list — Claude first so the setup wizard's "(Recommended)" marker lands on Claude.
@@ -73,6 +75,13 @@ def migrate_openclaw_config(root: Path) -> bool:
     # so any custom contextWindow / maxTokens overrides survive the migration.
     claude_models = [m for m in old_models if str(m.get("id", "")).startswith("claude")]
     other_models = [m for m in old_models if not str(m.get("id", "")).startswith("claude")]
+
+    # Backfill maxTokens on any model that lacks it — older configs were written before
+    # this field was standard, and without it OpenClaw falls back to a conservative cap
+    # that cuts long Cortex responses short. User-set values are preserved.
+    for model in (*claude_models, *other_models):
+        if isinstance(model, dict):
+            model.setdefault("maxTokens", DEFAULT_MAX_TOKENS)
 
     # If the old provider had no Claude entries (unusual but possible), seed with the
     # canonical Claude list so users still get the new endpoint.

--- a/tests/test_migrate_openclaw_config.py
+++ b/tests/test_migrate_openclaw_config.py
@@ -126,6 +126,28 @@ class TestProviderSplit:
         assert params["cacheRetention"] == "short"  # preserved
         assert params["temperature"] == 0.2
 
+    def test_missing_max_tokens_backfilled_with_default(self, tmp_path: Path):
+        """Old configs that predate the maxTokens field should get the standard default."""
+        _write_config(tmp_path, {
+            "models": {
+                "providers": {
+                    "cortex": {
+                        "models": [
+                            {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6"},
+                            {"id": "openai-gpt-5.1", "name": "GPT-5.1"},
+                        ],
+                    }
+                }
+            },
+            "agents": {"defaults": {"model": "cortex/claude-sonnet-4-6"}},
+        })
+        migrate_openclaw_config(tmp_path)
+        cfg = _read_config(tmp_path)
+        cc_models = cfg["models"]["providers"]["cortex-claude"]["models"]
+        co_models = cfg["models"]["providers"]["cortex-openai"]["models"]
+        assert cc_models[0]["maxTokens"] == 131072
+        assert co_models[0]["maxTokens"] == 131072
+
     def test_custom_models_in_old_provider_preserved_verbatim(self, tmp_path: Path):
         """User-customized contextWindow / maxTokens should survive the split."""
         _write_config(tmp_path, {


### PR DESCRIPTION
## Summary
- Extract `DEFAULT_MAX_TOKENS = 131072` constant in `snowclaw/config.py` and reuse it across the canonical Cortex model lists.
- `migrate_openclaw_config` now `setdefault`s `maxTokens` on every preserved model entry, so pre-existing configs that predate the field get the standard default while user overrides survive untouched.
- New test `test_missing_max_tokens_backfilled_with_default` covers backfill for both Claude and OpenAI models.

## Test plan
- [x] `pytest tests/test_migrate_openclaw_config.py` — all 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)