### PR TITLE
feat: default Claude context window to 1M

### DIFF
--- a/snowclaw/config.py
+++ b/snowclaw/config.py
@@ -10,9 +10,11 @@ from snowclaw.utils import console
 
 DEFAULT_MAX_TOKENS = 131072
 
+CORTEX_CLAUDE_CONTEXT_WINDOW = 1048576
+
 CORTEX_CLAUDE_MODELS = [
-    {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "contextWindow": 200000, "maxTokens": DEFAULT_MAX_TOKENS},
-    {"id": "claude-opus-4-6", "name": "Claude Opus 4.6", "contextWindow": 200000, "maxTokens": DEFAULT_MAX_TOKENS},
+    {"id": "claude-sonnet-4-6", "name": "Claude Sonnet 4.6", "contextWindow": CORTEX_CLAUDE_CONTEXT_WINDOW, "maxTokens": DEFAULT_MAX_TOKENS},
+    {"id": "claude-opus-4-6", "name": "Claude Opus 4.6", "contextWindow": CORTEX_CLAUDE_CONTEXT_WINDOW, "maxTokens": DEFAULT_MAX_TOKENS},
 ]
 
 CORTEX_OPENAI_MODELS = [
@@ -138,6 +140,59 @@ def migrate_openclaw_config(root: Path) -> bool:
         "  [yellow]→[/yellow] Migrated [cyan]openclaw.json[/cyan]: "
         "[dim]cortex →[/dim] cortex-openai + cortex-claude "
         "[dim](Claude models now use prompt caching)[/dim]"
+    )
+    console.print(
+        "  [dim]Note: if this project is already deployed, run "
+        "`snowclaw push --config-only` then `snowclaw restart` to apply.[/dim]"
+    )
+    return True
+
+
+def migrate_claude_context_window(root: Path) -> bool:
+    """Upgrade Claude model contextWindow from 200K to 1M in existing configs.
+
+    Claude 4.6 models on Cortex support a 1M context window. Projects created
+    before this default was changed still have ``contextWindow: 200000``.  This
+    migration bumps any Claude model that still carries the old 200K value to
+    the current ``CORTEX_CLAUDE_CONTEXT_WINDOW`` (1048576).  User-customised
+    values (anything other than 200000) are left untouched.
+
+    Returns True iff a change was written.
+    """
+    config_path = root / "openclaw.json"
+    if not config_path.exists():
+        return False
+
+    try:
+        config = json.loads(config_path.read_text())
+    except json.JSONDecodeError:
+        return False
+
+    providers = config.get("models", {}).get("providers", {})
+
+    OLD_CONTEXT_WINDOW = 200000
+    changed = False
+
+    for provider_id in ("cortex-claude", "cortex"):
+        provider = providers.get(provider_id)
+        if not provider:
+            continue
+        for model in provider.get("models", []):
+            if not isinstance(model, dict):
+                continue
+            if not str(model.get("id", "")).startswith("claude"):
+                continue
+            if model.get("contextWindow") == OLD_CONTEXT_WINDOW:
+                model["contextWindow"] = CORTEX_CLAUDE_CONTEXT_WINDOW
+                changed = True
+
+    if not changed:
+        return False
+
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+    console.print(
+        "  [yellow]→[/yellow] Migrated [cyan]openclaw.json[/cyan]: "
+        f"[dim]Claude contextWindow 200K → {CORTEX_CLAUDE_CONTEXT_WINDOW // 1000}K[/dim]"
     )
     console.print(
         "  [dim]Note: if this project is already deployed, run "

--- a/snowclaw/scaffold.py
+++ b/snowclaw/scaffold.py
@@ -8,7 +8,7 @@ import shutil
 import sys
 from pathlib import Path
 
-from snowclaw.config import migrate_openclaw_config
+from snowclaw.config import migrate_claude_context_window, migrate_openclaw_config
 from snowclaw.network import (
     CHANNEL_REGISTRY,
     TOOL_REGISTRY,
@@ -126,9 +126,9 @@ def assemble_build_context(root: Path) -> Path:
     openclaw_version = marker.get("openclaw_version", "latest")
     templates = get_templates_dir()
 
-    # Auto-migrate pre-existing openclaw.json (single `cortex` provider) to the
-    # cortex-claude/cortex-openai split. No-op if already migrated.
+    # Auto-migrate pre-existing openclaw.json. Each migration is idempotent.
     migrate_openclaw_config(root)
+    migrate_claude_context_window(root)
 
     build_dir = root / ".snowclaw" / "build"
 

--- a/tests/test_migrate_openclaw_config.py
+++ b/tests/test_migrate_openclaw_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from snowclaw.config import migrate_openclaw_config
+from snowclaw.config import CORTEX_CLAUDE_CONTEXT_WINDOW, migrate_claude_context_window, migrate_openclaw_config
 
 
 def _write_config(root: Path, config: dict) -> Path:
@@ -225,3 +225,117 @@ class TestNoop:
         assert cfg["channels"] == {"slack": {"enabled": True}}
         assert cfg["tools"] == {"web": {"search": {"provider": "brave"}}}
         assert cfg["customKey"] == {"nested": "value"}
+
+
+# ---------------------------------------------------------------------------
+# Claude context window migration (200K → 1M)
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeContextWindowMigration:
+    def test_upgrades_200k_to_1m(self, tmp_path: Path):
+        _write_config(tmp_path, {
+            "models": {
+                "providers": {
+                    "cortex-claude": {
+                        "api": "anthropic-messages",
+                        "models": [
+                            {"id": "claude-sonnet-4-6", "contextWindow": 200000, "maxTokens": 131072},
+                            {"id": "claude-opus-4-6", "contextWindow": 200000, "maxTokens": 131072},
+                        ],
+                    },
+                    "cortex-openai": {
+                        "api": "openai-completions",
+                        "models": [{"id": "openai-gpt-5.1", "contextWindow": 1047576}],
+                    },
+                }
+            },
+        })
+        assert migrate_claude_context_window(tmp_path) is True
+        cfg = _read_config(tmp_path)
+        cc_models = cfg["models"]["providers"]["cortex-claude"]["models"]
+        assert cc_models[0]["contextWindow"] == CORTEX_CLAUDE_CONTEXT_WINDOW
+        assert cc_models[1]["contextWindow"] == CORTEX_CLAUDE_CONTEXT_WINDOW
+        # OpenAI models untouched
+        co_models = cfg["models"]["providers"]["cortex-openai"]["models"]
+        assert co_models[0]["contextWindow"] == 1047576
+
+    def test_custom_context_window_preserved(self, tmp_path: Path):
+        """User-customized contextWindow (not 200K) should not be overwritten."""
+        _write_config(tmp_path, {
+            "models": {
+                "providers": {
+                    "cortex-claude": {
+                        "api": "anthropic-messages",
+                        "models": [
+                            {"id": "claude-sonnet-4-6", "contextWindow": 99999},
+                        ],
+                    },
+                }
+            },
+        })
+        assert migrate_claude_context_window(tmp_path) is False
+        cfg = _read_config(tmp_path)
+        assert cfg["models"]["providers"]["cortex-claude"]["models"][0]["contextWindow"] == 99999
+
+    def test_already_1m_is_noop(self, tmp_path: Path):
+        _write_config(tmp_path, {
+            "models": {
+                "providers": {
+                    "cortex-claude": {
+                        "api": "anthropic-messages",
+                        "models": [
+                            {"id": "claude-sonnet-4-6", "contextWindow": CORTEX_CLAUDE_CONTEXT_WINDOW},
+                        ],
+                    },
+                }
+            },
+        })
+        assert migrate_claude_context_window(tmp_path) is False
+
+    def test_missing_file_is_noop(self, tmp_path: Path):
+        assert migrate_claude_context_window(tmp_path) is False
+
+    def test_handles_old_cortex_provider(self, tmp_path: Path):
+        """Pre-split configs with old `cortex` provider should also be migrated."""
+        _write_config(tmp_path, {
+            "models": {
+                "providers": {
+                    "cortex": {
+                        "models": [
+                            {"id": "claude-sonnet-4-6", "contextWindow": 200000},
+                            {"id": "openai-gpt-5.1", "contextWindow": 1047576},
+                        ],
+                    },
+                }
+            },
+        })
+        assert migrate_claude_context_window(tmp_path) is True
+        cfg = _read_config(tmp_path)
+        models = cfg["models"]["providers"]["cortex"]["models"]
+        assert models[0]["contextWindow"] == CORTEX_CLAUDE_CONTEXT_WINDOW
+        assert models[1]["contextWindow"] == 1047576  # non-Claude untouched
+
+    def test_unrelated_keys_preserved(self, tmp_path: Path):
+        _write_config(tmp_path, {
+            "models": {
+                "providers": {
+                    "cortex-claude": {
+                        "api": "anthropic-messages",
+                        "baseUrl": "http://localhost:8080",
+                        "models": [
+                            {"id": "claude-sonnet-4-6", "contextWindow": 200000, "maxTokens": 131072},
+                        ],
+                    },
+                }
+            },
+            "agents": {"defaults": {"model": "cortex-claude/claude-sonnet-4-6"}},
+            "channels": {"slack": {"enabled": True}},
+        })
+        migrate_claude_context_window(tmp_path)
+        cfg = _read_config(tmp_path)
+        assert cfg["agents"]["defaults"]["model"] == "cortex-claude/claude-sonnet-4-6"
+        assert cfg["channels"] == {"slack": {"enabled": True}}
+        cc = cfg["models"]["providers"]["cortex-claude"]
+        assert cc["baseUrl"] == "http://localhost:8080"
+        assert cc["models"][0]["maxTokens"] == 131072


### PR DESCRIPTION
## Summary
- New setups now default Claude model `contextWindow` to 1,048,576 (1M) instead of 200,000
- Added `migrate_claude_context_window()` migration that auto-upgrades existing `openclaw.json` configs on next build/deploy
- Migration only touches Claude models still at the old 200K default — user-customized values are preserved
- Covers both `cortex-claude` (current) and legacy `cortex` (pre-split) provider shapes

## Test plan
- [x] 6 new tests in `test_migrate_openclaw_config.py` covering: upgrade path, custom value preservation, idempotency, missing file, old provider shape, unrelated key preservation
- [x] All 19 migration tests pass
- [ ] Manual: run `snowclaw setup` in a fresh directory → verify `openclaw.json` has `contextWindow: 1048576` for Claude models
- [ ] Manual: run `snowclaw dev`/`snowclaw deploy` on an existing project with 200K configs → verify migration message and updated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)