### PR TITLE
Workspace file-transfer commands; drop workspace from push/pull

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,8 +63,12 @@ my-openclaw/                 # User's project directory
   build-hooks/               # User-editable build scripts (*.sh, run alphabetically at build time)
   skills/                    # User-editable skills (copied from templates/)
     cortex-code/
-  workspace/                 # Markdown knowledge base (starts empty)
+    snowclaw/
 ```
+
+The agent's `workspace/` lives only on the SPCS stage / container volume and
+is managed via `snowclaw upload` / `download` / `ls`. It is intentionally not
+scaffolded locally and is not part of `push` / `pull`.
 
 ### Build context layout (generated into `.snowclaw/build/`)
 
@@ -105,8 +109,11 @@ Multi-module Python CLI using argparse + Rich + InquirerPy. Installed via `pipx 
 | `snowclaw restart` | Restart service to pick up config changes |
 | `snowclaw logs` | Fetch container logs (`-n`, `--container`, `--instance` flags) |
 | `snowclaw update` | Update `openclaw_version` in marker, optionally redeploy |
-| `snowclaw pull` | Pull from SPCS stage (`--workspace-only`, `--skills-only`, `--config-only`) |
-| `snowclaw push` | Push to SPCS stage (`--workspace-only`, `--skills-only`, `--config-only`) |
+| `snowclaw pull` | Pull skills/ and openclaw.json from SPCS stage (`--skills-only`, `--config-only`). Workspace files are not synced — use `snowclaw download` |
+| `snowclaw push` | Push skills/ and openclaw.json to SPCS stage (`--skills-only`, `--config-only`). Workspace files are not synced — use `snowclaw upload` |
+| `snowclaw ls [path]` | List files in the SPCS workspace (paths are workspace-relative) |
+| `snowclaw upload <local> [--dest <subdir>] [--force]` | Upload a local file into the SPCS workspace (live — agent sees it immediately) |
+| `snowclaw download <stage-path> [--dest <local-dir>]` | Download a file from the SPCS workspace to the local machine |
 | `snowclaw channel list` | Show configured channels |
 | `snowclaw channel add` | Interactive wizard to add a channel (Slack, Telegram, Discord) |
 | `snowclaw channel remove <name>` | Remove a channel |
@@ -383,8 +390,29 @@ Users can add custom Dockerfile layers via `build-hooks/` directory:
 - `snowclaw push --config-only` → uploads local config to stage
 - `snowclaw pull --config-only` → downloads config from stage
 - `snowclaw restart` → service picks up new config from volume
-- Skills and workspace also syncable via `--skills-only` / `--workspace-only`
-- No flags → syncs all three (skills + workspace + config)
+- Skills also syncable via `--skills-only`
+- No flags → syncs skills + config
+
+Workspace files are deliberately excluded from `push` / `pull` (they can be
+large and contain agent-generated artifacts). Move them with the dedicated
+file-transfer commands instead.
+
+## Workspace file transfer (`snowclaw ls` / `upload` / `download`)
+
+The agent's `workspace/` directory lives on the SPCS stage and is mounted
+live into the container at `/home/node/.openclaw/workspace`. Three commands
+move files in and out, all scoped to that directory:
+
+- `snowclaw ls [path]` — list workspace contents (paths workspace-relative).
+- `snowclaw upload <local> [--dest <subdir>] [--force]` — upload a file. The
+  underlying PUT is `OVERWRITE=TRUE`; the CLI prompts on existing destinations
+  unless `--force`. Local filename is preserved.
+- `snowclaw download <stage-path> [--dest <local-dir>]` — download a single
+  file. `--dest` defaults to cwd; basename is preserved.
+
+The `templates/skills/snowclaw/` skill teaches the agent to advise users on
+both these commands and the in-container presigned-URL flow (for chat-driven
+downloads).
 
 ## Plugins (`snowclaw/plugins.py`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,13 @@ my-openclaw/
   connections.toml        # Snowflake connection — gitignored
   skills/                 # Editable skill definitions
     cortex-code/
+    snowclaw/
   build-hooks/            # Custom build scripts (*.sh, run at image build time)
-  workspace/              # Markdown knowledge base
 ```
+
+The agent's `workspace/` lives only on the SPCS stage / container volume. It
+is not scaffolded locally and is not part of `snowclaw push` / `pull`. Move
+files in and out with `snowclaw upload` / `download` / `ls`.
 
 ## Project Layout (repo)
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SnowClaw is designed to be safe to run in your Snowflake account by default.
 - **Secrets & credential management** — All secrets live in your local `.env` file and are uploaded to Snowflake as individual SECRET objects on every `deploy` or `push`. Nothing is baked into the Docker image. Add any custom environment variable to `.env` and it automatically becomes a Snowflake secret, mounted into the container at runtime. See [Secrets & Credentials](#secrets--credentials) for details.
 - **Snowflake Cortex LLMs** — Pre-configured as a provider. Models run inside Snowflake — your data never leaves your account.
 - **Cortex Code** — AI coding assistant installed automatically in the container with a bundled skill definition. Your agent can write, edit, and manage code out of the box.
-- **Cortex proxy sidecar** — A FastAPI proxy between OpenClaw and Cortex that serializes parallel tool calls (fixing Claude model issues), normalizes request parameters across model families, and masks secrets in outbound traffic. Can also be deployed as a [standalone proxy](#standalone-proxy) for external OpenClaw agents.
+- **Cortex proxy sidecar** — A FastAPI proxy between OpenClaw and Cortex with two endpoints: `/v1/chat/completions` (OpenAI-shaped, for OpenAI/Snowflake/Llama models) and `/v1/messages` (Anthropic-shaped, for Claude models with native prompt caching). Handles parallel tool call serialization, request normalization, secret masking, response metadata logging, and automatic 1M context window headers for Claude. Can also be deployed as a [standalone proxy](#standalone-proxy) for external OpenClaw agents.
 - **Multi-channel messaging** — Slack, Telegram, and Discord supported out of the box. `snowclaw channel add` walks you through configuration with auto-detected network rules per channel.
 - **Dynamic network rules** — Auto-detects required external hosts from your config and prompts for approval before creating Snowflake network rules and external access integrations.
 - **Build hooks** — Drop `.sh` scripts into `build-hooks/` to install packages or tools at image build time. No Dockerfile editing needed.
@@ -66,14 +66,18 @@ Channels <--socket/ws--> SPCS Ingress <--> OpenClaw Gateway (:18789)
                                              +-- Plugin HTTP routes
                                              |
                                            Cortex Proxy Sidecar (:8080)
-                                             +-- Parallel tool call serialization
-                                             +-- Secret masking
-                                             +-- Request normalization
+                                             +-- POST /v1/chat/completions
+                                             |     (OpenAI/Snowflake/Llama — tool call serialization, request transforms)
+                                             +-- POST /v1/messages
+                                             |     (Claude — native prompt caching, no transforms needed)
+                                             +-- Secret masking (per-shape walker)
+                                             +-- Response metadata logging
+                                             +-- 1M context window headers (Claude)
                                              |
                                              +-- Snowflake Cortex (outbound)
 ```
 
-All traffic goes through a single SPCS ingress endpoint on port 18789. The Cortex proxy runs as a sidecar container in the same service. Snowflake handles TLS and authentication.
+All traffic goes through a single SPCS ingress endpoint on port 18789. The Cortex proxy runs as a sidecar container in the same service with two endpoints — one per API shape. Snowflake handles TLS and authentication.
 
 ## Secrets & Credentials
 
@@ -116,7 +120,7 @@ Variables listed in `SNOWCLAW_MASK_VARS` (a comma-separated list in `.env`) are 
 
 - `openclaw.json`, `secrets.json`, and the `credentials/` directory are **root-owned and read-only** (mode `440`). The agent process cannot modify configuration or credentials.
 - The `.snowflake/` directory (containing `connections.toml`) is owned by the `node` user so Cortex can read and write connection state.
-- `workspace/` and `skills/` are agent-writable.
+- `skills/` is agent-writable. The agent's `workspace/` lives only on the SPCS stage / container volume — it is not scaffolded locally and is not part of `push` / `pull`. Move files in and out with `snowclaw upload` / `download` / `ls`.
 
 ## CLI Commands
 
@@ -133,9 +137,12 @@ Variables listed in `SNOWCLAW_MASK_VARS` (a comma-separated list in `.env`) are 
 | `snowclaw restart` | Restart the service to pick up config changes |
 | `snowclaw logs` | Show container logs from the SPCS service |
 | `snowclaw update` | Update the OpenClaw base image version |
-| `snowclaw push` | Push skills, workspace, config, and secrets to SPCS stage |
+| `snowclaw push` | Push skills and openclaw.json (and secrets) to SPCS stage |
 | `snowclaw push --secrets` | Update only Snowflake secrets and connections.toml (skip file sync) |
-| `snowclaw pull` | Pull skills, workspace, and config from SPCS stage |
+| `snowclaw pull` | Pull skills and openclaw.json from SPCS stage |
+| `snowclaw ls [path]` | List files in the SPCS workspace (paths workspace-relative) |
+| `snowclaw upload <local> [--dest <subdir>] [--force]` | Upload a local file into the SPCS workspace (live — agent sees it immediately) |
+| `snowclaw download <stage-path> [--dest <local-dir>]` | Download a file from the SPCS workspace |
 | `snowclaw network list` | Show current approved network rules |
 | `snowclaw network add <host>` | Add a network rule (prompts to apply) |
 | `snowclaw network remove <host>` | Remove a network rule |
@@ -145,6 +152,9 @@ Variables listed in `SNOWCLAW_MASK_VARS` (a comma-separated list in `.env`) are 
 | `snowclaw channel add` | Interactive wizard to add a channel |
 | `snowclaw channel edit <name>` | Edit a channel's credentials |
 | `snowclaw channel remove <name>` | Remove a channel |
+| `snowclaw plugins list` | Show configured plugins |
+| `snowclaw plugins add <spec>` | Add a plugin (npm package or local path) |
+| `snowclaw plugins remove <id>` | Remove a plugin |
 | `snowclaw proxy setup` | Interactive wizard for standalone Cortex proxy |
 | `snowclaw proxy deploy` | Build, push, and deploy the standalone proxy to SPCS |
 | `snowclaw proxy status` | Show standalone proxy service status and endpoint |
@@ -152,7 +162,7 @@ Variables listed in `SNOWCLAW_MASK_VARS` (a comma-separated list in `.env`) are 
 | `snowclaw proxy resume` | Resume the standalone proxy compute pool and service |
 | `snowclaw proxy logs` | Show standalone proxy container logs |
 
-`push` and `pull` accept `--workspace-only`, `--skills-only`, or `--config-only` to sync selectively.
+`push` and `pull` accept `--skills-only` or `--config-only` to sync selectively. Workspace files are intentionally outside `push`/`pull` — use `snowclaw upload` / `download` / `ls` (all paths are relative to the workspace root).
 
 ## Standalone Proxy
 
@@ -172,41 +182,55 @@ After deploying, `snowclaw proxy deploy` prints the public endpoint URL and a re
 
 Each user authenticates to the SPCS endpoint with their own Snowflake PAT. SPCS ingress validates the token and injects `Sf-Context-Current-User` for traceability, but strips the `Authorization` header before it reaches the container. To get the PAT through to Cortex, OpenClaw sends it in a custom `X-Cortex-Token` header which SPCS passes through untouched. The proxy reads this header and forwards it to Cortex as a Bearer token.
 
+The proxy exposes both endpoints:
+
+- **`/v1/chat/completions`** — OpenAI-shaped, for OpenAI/Snowflake/Llama models (also accepts Claude via Cortex's translation layer, but without native caching)
+- **`/v1/messages`** — Anthropic-shaped, for Claude models with native prompt caching support
+
 ### OpenClaw provider config
 
-Add this to your external OpenClaw's `openclaw.json`:
+Add this to your external OpenClaw's `openclaw.json`. Use two providers to route Claude models through the Messages endpoint (for native caching) and everything else through chat completions:
 
 ```json5
 {
   models: {
     providers: {
-      cortex: {
+      "cortex-claude": {
+        baseUrl: "https://<proxy-endpoint>",
+        apiKey: "${SNOWFLAKE_TOKEN}",
+        headers: {
+          "X-Cortex-Token": "${SNOWFLAKE_TOKEN}"
+        },
+        api: "anthropic-messages"
+      },
+      "cortex-openai": {
         baseUrl: "https://<proxy-endpoint>/v1",
         apiKey: "${SNOWFLAKE_TOKEN}",
         headers: {
           "X-Cortex-Token": "${SNOWFLAKE_TOKEN}"
         },
-        api: "openai-completions",
-        models: [
-          { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
-          { id: "claude-opus-4-6", name: "Claude Opus 4.6" }
-        ]
+        api: "openai-completions"
       }
     }
   }
 }
 ```
 
+- `cortex-claude` — routes Claude models via `/v1/messages` with native `cache_control` marker support
+- `cortex-openai` — routes OpenAI, Snowflake, and Llama models via `/v1/chat/completions`
 - `apiKey` authenticates with SPCS ingress (sent as `Authorization: Snowflake Token="..."`)
 - `X-Cortex-Token` passes through ingress to the proxy, which forwards it to Cortex
 - Each user's PAT provides per-user identity and traceability via `Sf-Context-Current-User`
 
 ### Features
 
+- **Dual endpoints** — `/v1/chat/completions` for OpenAI-shaped requests, `/v1/messages` for Anthropic-shaped requests with native prompt caching
 - **No shared secrets** — each user sends their own PAT, no service-level token needed
 - **Per-user traceability** — SPCS injects `Sf-Context-Current-User` automatically
 - **Rate limit retry** — exponential backoff on Cortex 429 responses
-- **Request transforms** — parallel tool call serialization, max_tokens normalization
+- **Request transforms** — parallel tool call serialization, max_tokens normalization (chat completions only)
+- **1M context window** — automatic `anthropic-beta` header injection for Claude models
+- **Response metadata logging** — opt-in via `PROXY_LOG_RESPONSES` env var (usage stats, errors, cache hit rates)
 - **Minimal footprint** — single container on CPU_X64_XS compute pool
 
 ## License

--- a/snowclaw/cli.py
+++ b/snowclaw/cli.py
@@ -10,7 +10,9 @@ from snowclaw.commands import (
     cmd_channel,
     cmd_deploy,
     cmd_dev,
+    cmd_download,
     cmd_logs,
+    cmd_ls,
     cmd_model,
     cmd_network,
     cmd_plugins,
@@ -24,6 +26,7 @@ from snowclaw.commands import (
     cmd_suspend,
     cmd_update,
     cmd_upgrade,
+    cmd_upload,
 )
 
 
@@ -54,18 +57,41 @@ def build_parser() -> argparse.ArgumentParser:
     logs_parser.add_argument("--container", default="openclaw", help="Container name (default: openclaw)")
     logs_parser.add_argument("--instance", default="0", help="Instance ID (default: 0)")
 
-    pull_parser = sub.add_parser("pull", help="Pull skills, workspace, and config from SPCS stage")
+    pull_parser = sub.add_parser(
+        "pull",
+        help="Pull skills and config from SPCS stage (workspace files: use `snowclaw download`)",
+    )
     pull_group = pull_parser.add_mutually_exclusive_group()
-    pull_group.add_argument("--workspace-only", action="store_true", help="Only pull workspace/")
     pull_group.add_argument("--skills-only", action="store_true", help="Only pull skills/")
     pull_group.add_argument("--config-only", action="store_true", help="Only pull openclaw.json")
 
-    push_parser = sub.add_parser("push", help="Push skills, workspace, and config to SPCS stage")
+    push_parser = sub.add_parser(
+        "push",
+        help="Push skills and config to SPCS stage (workspace files: use `snowclaw upload`)",
+    )
     push_group = push_parser.add_mutually_exclusive_group()
-    push_group.add_argument("--workspace-only", action="store_true", help="Only push workspace/")
     push_group.add_argument("--skills-only", action="store_true", help="Only push skills/")
     push_group.add_argument("--config-only", action="store_true", help="Only push openclaw.json")
     push_parser.add_argument("--secrets", action="store_true", help="Only update secrets and connections.toml (skip target push when used alone)")
+
+    # --- snowclaw ls / upload / download (workspace file transfer) ---
+    ls_parser = sub.add_parser(
+        "ls", help="List files in the SPCS workspace (paths are workspace-relative)"
+    )
+    ls_parser.add_argument("path", nargs="?", default="", help="Subpath under workspace/ to list (default: workspace root)")
+
+    upload_parser = sub.add_parser(
+        "upload", help="Upload a local file into the SPCS workspace (live — agent sees it immediately)"
+    )
+    upload_parser.add_argument("local_path", help="Path to a local file to upload")
+    upload_parser.add_argument("--dest", default="", help="Destination subdirectory under workspace/ (default: workspace root). Filename is preserved.")
+    upload_parser.add_argument("--force", action="store_true", help="Overwrite without confirmation if destination already exists")
+
+    download_parser = sub.add_parser(
+        "download", help="Download a file from the SPCS workspace to the local machine"
+    )
+    download_parser.add_argument("stage_path", help="Workspace-relative path to download (e.g. report.csv or data/report.csv)")
+    download_parser.add_argument("--dest", default=".", help="Local destination directory (default: cwd). Filename is preserved.")
 
     # --- snowclaw network ---
     net_parser = sub.add_parser(
@@ -153,6 +179,9 @@ def main():
         "update": cmd_update,
         "pull": cmd_pull,
         "push": cmd_push,
+        "ls": cmd_ls,
+        "upload": cmd_upload,
+        "download": cmd_download,
         "network": cmd_network,
         "channel": cmd_channel,
         "plugins": cmd_plugins,

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -709,13 +709,11 @@ def cmd_update(args: argparse.Namespace):
 
 def _sync_targets(args: argparse.Namespace) -> list[str]:
     """Determine which targets to sync based on CLI flags."""
-    if getattr(args, "workspace_only", False):
-        return ["workspace"]
     if getattr(args, "skills_only", False):
         return ["skills"]
     if getattr(args, "config_only", False):
         return ["config"]
-    return ["skills", "workspace", "config"]
+    return ["skills", "config"]
 
 
 def cmd_pull(args: argparse.Namespace):
@@ -795,7 +793,7 @@ def cmd_push(args: argparse.Namespace):
 
     secrets_only = getattr(args, "secrets", False)
     has_target_flag = any(
-        getattr(args, f, False) for f in ("workspace_only", "skills_only", "config_only")
+        getattr(args, f, False) for f in ("skills_only", "config_only")
     )
 
     # Push targets unless --secrets is used alone
@@ -910,6 +908,171 @@ def cmd_push(args: argparse.Namespace):
     console.print(
         "[yellow]Note:[/yellow] The container may take a minute or two to fully spin up."
     )
+
+
+# ---------------------------------------------------------------------------
+# snowclaw ls / upload / download (workspace-scoped file transfer)
+# ---------------------------------------------------------------------------
+
+
+WORKSPACE_PREFIX = "workspace"
+
+
+def _open_workspace_connection(root: Path):
+    """Open a Snowflake connection for workspace operations.
+
+    Returns (conn, fqn_stage). Exits with an error message if credentials are
+    missing.
+    """
+    from snowclaw.stage import get_sf_connection
+
+    ctx = load_snowflake_context(root)
+    account = ctx["account"]
+    token = ctx["token"]
+    sf_user = ctx["user"]
+    names = ctx["names"]
+
+    if not all([account, token, sf_user]):
+        console.print("[red]Missing required credentials in .env.[/red]")
+        console.print("Required: SNOWFLAKE_ACCOUNT, SNOWFLAKE_TOKEN, SNOWFLAKE_USER")
+        sys.exit(1)
+
+    fqn_stage = f"{names['schema']}.{names['stage']}"
+    conn = get_sf_connection(
+        account=account,
+        user=sf_user,
+        token=token,
+        warehouse=ctx["warehouse"],
+        database=names["db"],
+        schema=names["schema_name"],
+    )
+    return conn, fqn_stage
+
+
+def _normalize_workspace_path(path: str | None) -> str:
+    """Strip leading slashes and normalize separators for a workspace-relative path."""
+    if not path:
+        return ""
+    cleaned = path.strip().lstrip("/").rstrip("/")
+    return cleaned
+
+
+def _format_size(num_bytes: int) -> str:
+    for unit in ("B", "KB", "MB", "GB"):
+        if num_bytes < 1024:
+            return f"{num_bytes:.1f} {unit}" if unit != "B" else f"{num_bytes} {unit}"
+        num_bytes /= 1024
+    return f"{num_bytes:.1f} TB"
+
+
+def cmd_ls(args: argparse.Namespace):
+    """List files in the SPCS workspace."""
+    from rich.table import Table
+
+    from snowclaw.stage import stage_list
+
+    render_banner()
+    root = find_project_root()
+
+    rel = _normalize_workspace_path(getattr(args, "path", None))
+    stage_prefix = f"{WORKSPACE_PREFIX}/{rel}" if rel else f"{WORKSPACE_PREFIX}/"
+
+    conn, fqn_stage = _open_workspace_connection(root)
+    try:
+        files = stage_list(conn, fqn_stage, prefix=stage_prefix)
+    finally:
+        conn.close()
+
+    display_label = rel if rel else "(root)"
+    if not files:
+        console.print(f"[dim]No files in workspace/{rel}[/dim]" if rel else "[dim]Workspace is empty.[/dim]")
+        return
+
+    table = Table(title=f"workspace/{rel}" if rel else "workspace/", show_header=True, header_style="bold")
+    table.add_column("path")
+    table.add_column("size", justify="right")
+    table.add_column("md5", style="dim")
+
+    workspace_marker = f"/{WORKSPACE_PREFIX}/"
+    for f in sorted(files, key=lambda r: r["name"]):
+        full_name = f["name"]
+        idx = full_name.find(workspace_marker)
+        rel_path = full_name[idx + len(workspace_marker):] if idx >= 0 else full_name
+        table.add_row(rel_path, _format_size(int(f["size"])), f["md5"] or "")
+
+    console.print(table)
+    console.print(f"[dim]{len(files)} file(s) under workspace/{rel}[/dim]" if rel else f"[dim]{len(files)} file(s) in workspace/[/dim]")
+
+
+def cmd_upload(args: argparse.Namespace):
+    """Upload a file to the SPCS workspace (live — agent sees it immediately)."""
+    from snowclaw.stage import stage_file_exists, stage_push_file
+
+    render_banner()
+    root = find_project_root()
+
+    local_path = Path(args.local_path).expanduser().resolve()
+    if not local_path.exists():
+        console.print(f"[red]Local file not found:[/red] {local_path}")
+        sys.exit(1)
+    if local_path.is_dir():
+        console.print("[red]Directory uploads are not supported.[/red] Upload individual files (or tar/zip first).")
+        sys.exit(1)
+
+    dest_dir = _normalize_workspace_path(getattr(args, "dest", None))
+    stage_dir = f"{WORKSPACE_PREFIX}/{dest_dir}" if dest_dir else WORKSPACE_PREFIX
+    target_path = f"{stage_dir}/{local_path.name}"
+
+    conn, fqn_stage = _open_workspace_connection(root)
+    try:
+        if not getattr(args, "force", False):
+            if stage_file_exists(conn, fqn_stage, target_path):
+                proceed = inquirer.confirm(
+                    message=f"workspace/{dest_dir + '/' if dest_dir else ''}{local_path.name} already exists. Overwrite?",
+                    default=False,
+                ).execute()
+                if not proceed:
+                    console.print("[yellow]Upload cancelled.[/yellow]")
+                    return
+
+        console.print(f"[bold]Uploading {local_path.name} → workspace/{dest_dir + '/' if dest_dir else ''}{local_path.name}...[/bold]")
+        stage_push_file(conn, fqn_stage, str(local_path), stage_dir)
+    finally:
+        conn.close()
+
+    console.print(f"  [green]✓[/green] Uploaded to workspace/{dest_dir + '/' if dest_dir else ''}{local_path.name}")
+    console.print("[dim]The workspace volume is live-mounted — the agent sees this file immediately.[/dim]")
+
+
+def cmd_download(args: argparse.Namespace):
+    """Download a file from the SPCS workspace to the local machine."""
+    from snowclaw.stage import stage_file_exists, stage_pull_file
+
+    render_banner()
+    root = find_project_root()
+
+    rel = _normalize_workspace_path(args.stage_path)
+    if not rel:
+        console.print("[red]Specify a workspace-relative path to download.[/red]")
+        sys.exit(1)
+    stage_path = f"{WORKSPACE_PREFIX}/{rel}"
+
+    dest_dir = Path(getattr(args, "dest", None) or ".").expanduser().resolve()
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    conn, fqn_stage = _open_workspace_connection(root)
+    try:
+        if not stage_file_exists(conn, fqn_stage, stage_path):
+            console.print(f"[red]Not found on stage:[/red] workspace/{rel}")
+            sys.exit(1)
+
+        console.print(f"[bold]Downloading workspace/{rel} → {dest_dir}/...[/bold]")
+        stage_pull_file(conn, fqn_stage, stage_path, str(dest_dir))
+    finally:
+        conn.close()
+
+    local_file = dest_dir / Path(rel).name
+    console.print(f"  [green]✓[/green] Downloaded to {local_file}")
 
 
 # ---------------------------------------------------------------------------
@@ -1960,15 +2123,24 @@ def _proxy_deploy(args: argparse.Namespace):
     console.print("[green]Proxy deployment complete.[/green]")
 
     # Print OpenClaw provider config snippet
-    base_url = f"{endpoint_url}/v1" if endpoint_url else "https://<proxy-endpoint>/v1"
+    base_url_root = endpoint_url if endpoint_url else "https://<proxy-endpoint>"
+    base_url_v1 = f"{base_url_root}/v1"
     console.print()
     console.print(Panel(
         '[bold]Add this to your openclaw.json to connect through the proxy:[/bold]\n\n'
         '[cyan]{\n'
         '  "models": {\n'
         '    "providers": {\n'
-        '      "cortex": {\n'
-        f'        "baseUrl": "{base_url}",\n'
+        '      "cortex-claude": {\n'
+        f'        "baseUrl": "{base_url_root}",\n'
+        '        "apiKey": "$SNOWFLAKE_TOKEN",\n'
+        '        "headers": {\n'
+        '          "X-Cortex-Token": "$SNOWFLAKE_TOKEN"\n'
+        '        },\n'
+        '        "api": "anthropic-messages"\n'
+        '      },\n'
+        '      "cortex-openai": {\n'
+        f'        "baseUrl": "{base_url_v1}",\n'
         '        "apiKey": "$SNOWFLAKE_TOKEN",\n'
         '        "headers": {\n'
         '          "X-Cortex-Token": "$SNOWFLAKE_TOKEN"\n'
@@ -1978,9 +2150,10 @@ def _proxy_deploy(args: argparse.Namespace):
         '    }\n'
         '  }\n'
         '}[/cyan]\n\n'
-        '[dim]Each user authenticates to the endpoint with their own PAT.\n'
-        'The apiKey handles SPCS ingress auth, while X-Cortex-Token\n'
-        'is passed through to Cortex for the actual LLM request.[/dim]',
+        '[dim]Use cortex-claude for Claude models (native caching via /v1/messages).\n'
+        'Use cortex-openai for OpenAI, Snowflake, and Llama models (/v1/chat/completions).\n'
+        'Each user authenticates with their own PAT — apiKey handles SPCS ingress auth,\n'
+        'while X-Cortex-Token is passed through to Cortex for the actual LLM request.[/dim]',
         title="OpenClaw Provider Config",
         border_style="green",
         expand=False,

--- a/snowclaw/scaffold.py
+++ b/snowclaw/scaffold.py
@@ -47,8 +47,10 @@ volumes:
 def scaffold_user_files(target: Path, force: bool = False) -> tuple[list[str], list[str]]:
     """Scaffold only user-editable files into the project directory.
 
-    Copies: skills/, .gitignore. Creates: workspace/.
+    Copies: skills/, .gitignore.
     Does NOT copy Dockerfile, docker-compose.yml, scripts/, spcs/, plugins/.
+    workspace/ is NOT scaffolded — it lives only on the SPCS stage / container
+    volume and is managed via `snowclaw upload`/`download`/`ls`.
     """
     templates = get_templates_dir()
     if not templates.is_dir():
@@ -82,13 +84,6 @@ def scaffold_user_files(target: Path, force: bool = False) -> tuple[list[str], l
         else:
             shutil.copy2(gitignore_src, dest)
             copied.append(".gitignore")
-
-    # Create workspace/ directory
-    workspace = target / "workspace"
-    if not workspace.exists():
-        workspace.mkdir()
-        (workspace / ".gitkeep").touch()
-        copied.append("workspace/")
 
     # Create build-hooks/ directory with README
     build_hooks = target / "build-hooks"

--- a/snowclaw/stage.py
+++ b/snowclaw/stage.py
@@ -62,6 +62,16 @@ def stage_list(
     return [{"name": row[0], "size": row[1], "md5": row[2]} for row in rows]
 
 
+def stage_file_exists(
+    conn: snowflake.connector.SnowflakeConnection,
+    fqn_stage: str,
+    stage_path: str,
+) -> bool:
+    """Check whether a specific file exists at `stage_path` on the stage."""
+    files = stage_list(conn, fqn_stage, prefix=stage_path)
+    return any(files)
+
+
 def stage_pull_file(
     conn: snowflake.connector.SnowflakeConnection,
     fqn_stage: str,

--- a/templates/skills/snowclaw/SKILL.md
+++ b/templates/skills/snowclaw/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: snowclaw
+description: >
+  Reference for advising the user on SnowClaw features. Covers how files move
+  between the user's machine, this container, and the SPCS stage; how
+  push/pull is scoped; and where to point the user for managing channels,
+  plugins, network rules, and the cortex proxy. Load the linked references on
+  demand — most sections are a one-line pointer.
+user-invocable: false
+---
+
+# SnowClaw
+
+You are running inside a SnowClaw deployment on Snowflake Container Services
+(SPCS). The user manages this deployment with the `snowclaw` CLI on their host
+machine. Use this skill when the user asks how to do something with SnowClaw
+itself (move files, change config, restart, manage channels, etc.) — not for
+day-to-day coding work.
+
+## File transfer (user ↔ workspace)
+
+Two transports are available; pick based on direction and whether the user is
+in chat or at a terminal.
+
+- **You (in container) → user (download via chat link)** — generate a presigned
+  URL the user can click. This is the only download path that works without
+  the user touching their terminal. Tokens, code template, gotchas:
+  [references/file-transfer.md](references/file-transfer.md).
+- **User (host) → workspace (upload)** — `snowclaw upload <local-path>
+  [--dest <subdir>] [--force]`. Live-mounted; you see the file immediately.
+- **Workspace → user (host download)** — `snowclaw download <workspace-path>
+  [--dest <local-dir>]`.
+- **List workspace contents** — `snowclaw ls [path]`. Default lists
+  workspace root.
+
+All `upload` / `download` / `ls` paths are relative to `workspace/` — the user
+never specifies the `workspace/` prefix. When you tell the user where you put
+a new file, give the workspace-relative path (e.g. `report.csv`, not
+`/home/node/.openclaw/workspace/report.csv`).
+
+For multi-file or large transfers, see the tarball recipe in
+[references/file-transfer.md](references/file-transfer.md).
+
+## Push / pull semantics
+
+`snowclaw push` and `snowclaw pull` only sync `skills/` and `openclaw.json`
+between the user's project directory and the SPCS stage. **Workspace files
+are deliberately not part of push/pull** — they can grow large and contain
+agent-generated artifacts. Use `upload`/`download`/`ls` for workspace files.
+
+Flags: `--skills-only`, `--config-only` for either direction; `push --secrets`
+to refresh Snowflake secrets without touching files.
+
+## Other SnowClaw areas
+
+For each of these, point the user at `snowclaw <subcommand> --help` rather
+than guessing at flags:
+
+- **Channels** (Slack / Telegram / Discord) — `snowclaw channel {list, add, remove, edit}`.
+- **Plugins** — `snowclaw plugins {list, add, remove}`.
+- **Network rules** (SPCS egress) — `snowclaw network {list, add, remove, detect, apply}`.
+- **Lifecycle** — `snowclaw {status, suspend, resume, restart, logs}`.
+- **Standalone Cortex proxy** — `snowclaw proxy {setup, deploy, status, suspend, resume, logs}`.

--- a/templates/skills/snowclaw/references/file-transfer.md
+++ b/templates/skills/snowclaw/references/file-transfer.md
@@ -1,0 +1,148 @@
+# File Transfer
+
+Two ways to move files between the user's machine and the SnowClaw workspace.
+Use the **presigned URL** path when you (the in-container agent) need to hand
+the user a downloadable file from chat. Use the **host-side CLI** path when
+the user is at a terminal — it's simpler, scriptable, and doesn't expose a
+public URL.
+
+---
+
+## 1. Presigned URLs from inside the container
+
+The workspace at `/home/node/.openclaw/workspace/` is an s3fs mount backed by
+a Snowflake internal stage. You can generate a time-limited presigned download
+URL for any file in the workspace and hand it to the user in chat.
+
+### Use the right token
+
+There are two tokens available in the container:
+
+- `/snowflake/session/token` — the SPCS service identity. Generates URLs that
+  point at an internal S3 access point (`spcs-ap-*-s3alias.s3...`). **These
+  return AccessDenied from outside.**
+- `$SNOWFLAKE_TOKEN` env var — the user's PAT (Programmatic Access Token).
+  Generates URLs through Snowflake's customer-facing S3 path
+  (`sfc-prod3-*-customer-stage.s3...`). **These work externally.**
+
+You must use `$SNOWFLAKE_TOKEN` with the `PROGRAMMATIC_ACCESS_TOKEN`
+authenticator and an explicit `user=$SNOWFLAKE_USER`.
+
+### Generate a download URL
+
+```python
+import os
+import snowflake.connector
+
+conn = snowflake.connector.connect(
+    account=os.environ['SNOWFLAKE_ACCOUNT'],
+    user=os.environ['SNOWFLAKE_USER'],
+    authenticator='PROGRAMMATIC_ACCESS_TOKEN',
+    token=os.environ['SNOWFLAKE_TOKEN'],
+    database=os.environ.get('SNOWCLAW_DB'),
+    schema=os.environ.get('SNOWCLAW_SCHEMA'),
+    warehouse=os.environ.get('SNOWFLAKE_WAREHOUSE'),
+)
+
+url = conn.cursor().execute("""
+    SELECT GET_PRESIGNED_URL(
+        @<state_stage>,
+        '<stage_path>',
+        3600  -- expiry in seconds (max 3600)
+    )
+""").fetchone()[0]
+```
+
+Substitute `<state_stage>` with the project's state stage (visible in
+`connections.toml` / setup logs; typically `<prefix>_state_stage`).
+
+### Stage path mapping
+
+The workspace mount is:
+
+- Filesystem: `/home/node/.openclaw/workspace/`
+- Stage: `@<prefix>_state_stage`
+- Path on stage: `workspace/<filename>`
+
+So `/home/node/.openclaw/workspace/foo.txt` → stage path `workspace/foo.txt`.
+
+### Large files / directories
+
+```bash
+tar czf <name>.tar.gz --exclude='.git' <directory>/
+```
+
+(`zip` is not installed.) The tarball lands in the workspace and is
+immediately visible on the stage via s3fs. Generate a presigned URL for the
+tarball and clean it up after the user confirms download.
+
+### Gotchas
+
+- s3fs is slow for recursive operations (`find`, large `ls -R`). Keep listings
+  shallow.
+- `GET_PRESIGNED_URL` with the SPCS session token produces URLs that look
+  valid but return AccessDenied externally — the bucket policy explicitly
+  denies external access from the SPCS IAM identity. Always use the user's PAT.
+- URLs expire (max 3600s). Generate fresh ones as needed.
+- `BUILD_SCOPED_FILE_URL` and `BUILD_STAGE_FILE_URL` exist but require
+  Snowflake session auth to access — not useful for direct browser downloads.
+
+---
+
+## 2. Host-side CLI commands
+
+When the user is at a terminal, recommend these instead — no URL handling, no
+expiry, no token confusion. All paths are relative to `workspace/`; the user
+never types the `workspace/` prefix.
+
+### `snowclaw ls [path]`
+
+List files under `workspace/<path>` (or workspace root if `path` is omitted).
+Cheap; safe to run repeatedly. Output is a Rich table with name, size, and
+md5.
+
+```
+snowclaw ls
+snowclaw ls data/
+```
+
+### `snowclaw download <stage-path> [--dest <local-dir>]`
+
+Pull a single workspace file to the user's machine. `--dest` defaults to the
+current working directory. The file keeps its basename.
+
+```
+snowclaw download report.csv
+snowclaw download data/report.csv --dest ./out/
+```
+
+### `snowclaw upload <local-path> [--dest <subpath>] [--force]`
+
+Push a single local file into the workspace. The workspace volume is
+**live-mounted** — once upload finishes, the file is visible at
+`/home/node/.openclaw/workspace/...` immediately. No restart required.
+
+- `--dest` is a *subdirectory* under `workspace/`. The local filename is
+  preserved (`PUT` cannot rename in flight).
+- Without `--force`, the CLI prompts to confirm if a file already exists at
+  the target path.
+- Directory uploads are not supported in v1; tar/zip first if you need to
+  send a tree.
+
+```
+snowclaw upload report.csv                    # → workspace/report.csv
+snowclaw upload report.csv --dest data/       # → workspace/data/report.csv
+snowclaw upload report.csv --force            # silent overwrite
+```
+
+### How to advise the user
+
+When you place a file the user should download, tell them the workspace path
+and offer them the choice:
+
+> I've written the analysis to `reports/q1-summary.md` in your workspace. You
+> can pull it down with `snowclaw download reports/q1-summary.md`, or I can
+> generate a presigned URL if you'd rather click a link.
+
+Don't invent an `inbox/` or other naming convention — just be explicit about
+where you put the file.


### PR DESCRIPTION
## Summary
- `snowclaw push` / `pull` now sync only `skills/` + `openclaw.json`. The `--workspace-only` flag is removed and the local `workspace/` directory is no longer scaffolded by `snowclaw setup` — it lives only on the SPCS stage / container volume.
- Adds three new top-level commands, all workspace-scoped (paths are relative to the workspace root):
  - `snowclaw ls [path]` — list workspace contents.
  - `snowclaw upload <local> [--dest <subdir>] [--force]` — upload a single file (live; agent sees it immediately). Prompts on overwrite unless `--force`.
  - `snowclaw download <stage-path> [--dest <local-dir>]` — pull a single workspace file to the local machine.
- New `templates/skills/snowclaw/` skill (progressive disclosure: `SKILL.md` index + `references/file-transfer.md`) teaches the agent to advise users on both the new CLI commands and the in-container presigned-URL flow.
- `CLAUDE.md`, `README.md`, and `CONTRIBUTING.md` updated to reflect the new layout and commands.

## Test plan
- [x] `pytest tests/` — 140 passed
- [x] `snowclaw --help` and `snowclaw {ls,upload,download} --help` render correctly
- [ ] `snowclaw setup` in a fresh dir — no local `workspace/` is created; `skills/snowclaw/` is present
- [ ] `snowclaw pull` against a deployed service — only `openclaw.json` and `skills/*` come down (workspace files are not touched); confirm `--workspace-only` no longer exists
- [ ] `snowclaw push` against a deployed service — same; workspace files on disk are never uploaded
- [ ] `snowclaw ls` lists workspace root; `snowclaw ls subdir/` lists subdir
- [ ] `snowclaw upload report.csv` lands at `workspace/report.csv`; `--dest data/` lands at `workspace/data/report.csv`
- [ ] Upload over an existing path prompts to confirm; `--force` skips the prompt
- [ ] After upload, file is visible in the running container at `/home/node/.openclaw/workspace/...` without restart
- [ ] `snowclaw download report.csv` writes to cwd; `--dest ./out/` writes to `./out/`
- [ ] `snowclaw build` still succeeds (build-context `workspace/` directory is still created for the Dockerfile `COPY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)