### PR TITLE
feat: allow-all egress mode for network rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,11 +114,13 @@ Multi-module Python CLI using argparse + Rich + InquirerPy. Installed via `pipx 
 | `snowclaw plugins list` | List configured plugins |
 | `snowclaw plugins add <spec>` | Add a plugin (npm package or local path) |
 | `snowclaw plugins remove <id>` | Remove a plugin |
-| `snowclaw network list` | Show current approved network rules |
+| `snowclaw network list` | Show current approved network rules (and egress mode) |
 | `snowclaw network add <host[:port]>` | Add a network rule, prompts to apply |
 | `snowclaw network remove <host[:port]>` | Remove a network rule, prompts to apply |
 | `snowclaw network detect` | Auto-detect rules from config, show diff, optionally save and apply |
-| `snowclaw network apply` | Push all saved rules to Snowflake |
+| `snowclaw network apply` | Push saved rules (or allow-all) to Snowflake |
+| `snowclaw network allow-all` | Enable unrestricted egress (`0.0.0.0:443`, `0.0.0.0:80`) — red warning + confirm |
+| `snowclaw network restrict` | Disable allow-all and re-apply the saved allowlist |
 | `snowclaw proxy setup` | Interactive wizard for standalone Cortex proxy deployment |
 | `snowclaw proxy deploy` | Build, push, and deploy standalone proxy to SPCS |
 | `snowclaw proxy status` | Show standalone proxy service status and endpoint |
@@ -355,17 +357,24 @@ SPCS blocks all outbound traffic by default. SnowClaw manages network rules and 
 ### How it works
 
 1. **Auto-detection** (`detect_required_rules()`): Parses `openclaw.json` for provider/channel/tool hostnames. Always includes `*.snowflakecomputing.com:443` for Cortex.
-2. **Persistence**: Rules saved to `.snowclaw/network-rules.json` (committed to git).
+2. **Persistence**: `.snowclaw/network-rules.json` holds `{ "allow_all_egress": bool, "rules": [...] }` (committed to git). Legacy files without `allow_all_egress` default to `false`.
 3. **Diff engine** (`diff_rules()`): Compares saved vs. detected rules. Returns `(added, removed)`.
 4. **SQL generation**: Steady-state updates use `ALTER NETWORK RULE … SET VALUE_LIST = (…)`; the NR and EAI are only `CREATE`d when missing (existence checked via `SHOW NETWORK RULES` / `SHOW EXTERNAL ACCESS INTEGRATIONS`). The reference `network-rules.sql` file emitted into the build context still uses `CREATE OR REPLACE` for one-shot apply to fresh schemas.
 5. **Application**: Executes via Snowflake REST API. Changes take effect without redeploying the SPCS service — the NR object identity is preserved by `ALTER`, so the EAI binding stays valid.
 
+### Egress modes
+
+Two modes, stored in `network-rules.json`:
+
+- **Allowlist** (default, safe): detection/diff/approve flow above. Exactly the required hosts are permitted.
+- **Allow all** (opt-in): `VALUE_LIST = ('0.0.0.0:443', '0.0.0.0:80')` — Snowflake's documented catch-all host pattern, which only supports ports 443 and 80 ([Snowflake docs: Network rules](https://docs.snowflake.com/en/user-guide/network-rules)). Enabled via `snowclaw network allow-all` behind a red warning panel + explicit `default=False` confirm. The saved `rules` list is preserved when allow-all is enabled so `snowclaw network restrict` restores the prior allowlist in one command. While allow-all is active, `network add`/`remove` still persist changes to the saved list and print a yellow note that the change won't take effect until `restrict` is run. Setup also offers an optional `"Skip the allowlist and permit all outbound traffic instead?"` prompt (defaulting to No) after the allowlist approval step.
+
 ### Integration points
 
-- **`cmd_setup()`**: Detects rules, prompts for approval, applies alongside other Snowflake objects.
-- **`cmd_deploy()`**: Diffs saved vs. detected before building; prompts if changes found.
-- **`assemble_build_context()`**: Generates `spcs/network-rules.sql` for reference.
-- **`cmd_network()`**: Manual management — `list`, `add`, `remove`, `detect`, `apply`.
+- **`cmd_setup()`**: Detects rules, prompts for approval, optionally offers allow-all opt-in, applies alongside other Snowflake objects.
+- **`cmd_deploy()`**: In allowlist mode, diffs saved vs. detected before building; in allow-all mode, skips detection and just ensures the allow-all NR is applied.
+- **`assemble_build_context()`**: Generates `spcs/network-rules.sql` for reference, honoring the current mode.
+- **`cmd_network()`**: Manual management — `list`, `add`, `remove`, `detect`, `apply`, `allow-all`, `restrict`.
 
 ## Build Hooks
 

--- a/snowclaw/cli.py
+++ b/snowclaw/cli.py
@@ -84,6 +84,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     net_sub.add_parser("apply", help="Apply current rules to Snowflake")
     net_sub.add_parser("detect", help="Auto-detect required rules from project config")
+    net_sub.add_parser(
+        "allow-all",
+        help="Permit all outbound traffic (0.0.0.0:443, 0.0.0.0:80) — NOT RECOMMENDED",
+    )
+    net_sub.add_parser(
+        "restrict",
+        help="Disable allow-all mode and re-apply the saved allowlist",
+    )
 
     # --- snowclaw channel ---
     ch_parser = sub.add_parser(

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -24,19 +24,23 @@ from snowclaw.channels import (
     channel_remove,
 )
 from snowclaw.network import (
+    ALLOW_ALL_VALUE_LIST,
     CHANNEL_REGISTRY,
     TOOL_REGISTRY,
     NetworkRule,
+    NetworkRulesConfig,
     apply_network_rules,
     detect_required_rules,
     diff_rules,
     format_rules_table,
     get_channel_secrets,
     get_env_secrets,
+    load_network_config,
     load_network_rules,
     offer_apply_rules,
     parse_host_port,
     print_diff,
+    save_network_config,
     save_network_rules,
 )
 from snowclaw.scaffold import assemble_build_context, assemble_proxy_build_context, scaffold_user_files
@@ -258,6 +262,27 @@ def cmd_setup(args: argparse.Namespace):
     else:
         console.print("  [dim]No external network rules detected.[/dim]")
 
+    # Offer the allow-all opt-in after the safe-default allowlist flow above.
+    console.print()
+    skip_allowlist = inquirer.confirm(
+        message="Skip the allowlist and permit all outbound traffic instead? (not recommended)",
+        default=False,
+    ).execute()
+    if skip_allowlist:
+        from snowclaw.network import print_allow_all_warning
+
+        print_allow_all_warning()
+        console.print()
+        confirm_allow_all = inquirer.confirm(
+            message="Enable allow-all egress?",
+            default=False,
+        ).execute()
+        if confirm_allow_all:
+            cfg = load_network_config(root)
+            cfg.allow_all_egress = True
+            save_network_config(root, cfg)
+            console.print("[bold red]Allow-all egress enabled.[/bold red]")
+
     # --- Optionally create Snowflake objects ---
     console.print()
     create_objects = inquirer.confirm(
@@ -265,7 +290,7 @@ def cmd_setup(args: argparse.Namespace):
         default=True,
     ).execute()
 
-    approved_rules = load_network_rules(root)
+    cfg = load_network_config(root)
 
     if create_objects:
         console.print()
@@ -276,11 +301,12 @@ def cmd_setup(args: argparse.Namespace):
         except Exception:
             console.print("[yellow]Some objects may not have been created. You can retry or create them manually.[/yellow]")
 
-        # Apply approved network rules
-        if approved_rules:
+        # Apply approved network rules (or allow-all)
+        if cfg.allow_all_egress or cfg.rules:
             console.print()
             apply_network_rules(
-                settings["account"], settings["pat"], names, approved_rules
+                settings["account"], settings["pat"], names, cfg.rules,
+                allow_all=cfg.allow_all_egress,
             )
 
     # --- Summary ---
@@ -476,41 +502,51 @@ def cmd_deploy(args: argparse.Namespace):
 
     # Check network rules before deploying
     console.print("[bold]Checking network rules...[/bold]")
-    current_rules = load_network_rules(root)
-    detected_rules = detect_required_rules(root)
-    added, removed = diff_rules(current_rules, detected_rules)
+    cfg = load_network_config(root)
+    current_rules = cfg.rules
 
-    if added or removed:
-        console.print()
-        console.print("[bold]Network rule changes detected:[/bold]")
-        print_diff(added, removed)
-        console.print()
-        approve = inquirer.confirm(
-            message="Approve these network rule changes?",
-            default=True,
-        ).execute()
-        if approve:
-            # Merge changes
-            removed_set = {(r.host, r.port) for r in removed}
-            merged = [r for r in current_rules if (r.host, r.port) not in removed_set]
-            existing_set = {(r.host, r.port) for r in merged}
-            for r in added:
-                if (r.host, r.port) not in existing_set:
-                    merged.append(r)
-            save_network_rules(root, merged)
-            apply_network_rules(account, token, names, merged)
-            console.print()
-        else:
-            console.print("[dim]Keeping existing network rules.[/dim]")
-            if current_rules:
-                console.print()
-    elif current_rules:
-        console.print(f"  [green]✓[/green] {len(current_rules)} rules up to date")
+    if cfg.allow_all_egress:
+        console.print(
+            "  [bold red]Egress mode: ALLOW ALL[/bold red] "
+            "[dim](unrestricted — 0.0.0.0:443, 0.0.0.0:80)[/dim]"
+        )
+        apply_network_rules(account, token, names, current_rules, allow_all=True)
         console.print()
     else:
-        console.print("  [yellow]No network rules configured.[/yellow]")
-        console.print("  [dim]External access will be unavailable. Use [cyan]snowclaw network add <host>[/cyan] to add rules.[/dim]")
-        console.print()
+        detected_rules = detect_required_rules(root)
+        added, removed = diff_rules(current_rules, detected_rules)
+
+        if added or removed:
+            console.print()
+            console.print("[bold]Network rule changes detected:[/bold]")
+            print_diff(added, removed)
+            console.print()
+            approve = inquirer.confirm(
+                message="Approve these network rule changes?",
+                default=True,
+            ).execute()
+            if approve:
+                # Merge changes
+                removed_set = {(r.host, r.port) for r in removed}
+                merged = [r for r in current_rules if (r.host, r.port) not in removed_set]
+                existing_set = {(r.host, r.port) for r in merged}
+                for r in added:
+                    if (r.host, r.port) not in existing_set:
+                        merged.append(r)
+                save_network_rules(root, merged)
+                apply_network_rules(account, token, names, merged)
+                console.print()
+            else:
+                console.print("[dim]Keeping existing network rules.[/dim]")
+                if current_rules:
+                    console.print()
+        elif current_rules:
+            console.print(f"  [green]✓[/green] {len(current_rules)} rules up to date")
+            console.print()
+        else:
+            console.print("  [yellow]No network rules configured.[/yellow]")
+            console.print("  [dim]External access will be unavailable. Use [cyan]snowclaw network add <host>[/cyan] to add rules.[/dim]")
+            console.print()
 
     # Assemble build context
     console.print("[bold]Assembling build context...[/bold]")
@@ -931,19 +967,45 @@ def cmd_network(args: argparse.Namespace):
         "remove": _network_remove,
         "apply": _network_apply,
         "detect": _network_detect,
+        "allow-all": _network_allow_all,
+        "restrict": _network_restrict,
     }
     handler = dispatch.get(sub)
     if handler:
         handler(args)
 
 
+def _print_allow_all_banner():
+    console.print(
+        "[bold red]Egress mode: ALLOW ALL[/bold red] "
+        "[dim](unrestricted — 0.0.0.0:443, 0.0.0.0:80)[/dim]"
+    )
+
+
+def _print_allow_all_warning_note(action: str):
+    console.print(
+        f"[yellow]Note:[/yellow] allow-all egress is active; this {action} won't take effect "
+        "until you run [cyan]snowclaw network restrict[/cyan]."
+    )
+
+
 def _network_list(args: argparse.Namespace):
     """List current approved network rules."""
     render_banner()
     root = find_project_root()
-    rules = load_network_rules(root)
+    cfg = load_network_config(root)
 
-    if not rules:
+    if cfg.allow_all_egress:
+        _print_allow_all_banner()
+        console.print()
+        if cfg.rules:
+            console.print(
+                "[dim]Saved allowlist (restored on [cyan]snowclaw network restrict[/cyan]):[/dim]"
+            )
+            console.print(format_rules_table(cfg.rules))
+        return
+
+    if not cfg.rules:
         console.print("[dim]No network rules configured.[/dim]")
         console.print(
             "Run [cyan]snowclaw network detect[/cyan] to auto-detect required rules,"
@@ -953,15 +1015,16 @@ def _network_list(args: argparse.Namespace):
         )
         return
 
-    console.print(format_rules_table(rules))
-    console.print(f"\n[dim]{len(rules)} rule(s) total[/dim]")
+    console.print(format_rules_table(cfg.rules))
+    console.print(f"\n[dim]{len(cfg.rules)} rule(s) total[/dim]")
 
 
 def _network_add(args: argparse.Namespace):
     """Add a network rule."""
     render_banner()
     root = find_project_root()
-    rules = load_network_rules(root)
+    cfg = load_network_config(root)
+    rules = cfg.rules
 
     host_input = getattr(args, "host", None)
     if not host_input:
@@ -988,6 +1051,10 @@ def _network_add(args: argparse.Namespace):
     save_network_rules(root, rules)
     console.print(f"[green]✓[/green] Added [cyan]{new_rule.host_port}[/cyan]")
 
+    if cfg.allow_all_egress:
+        _print_allow_all_warning_note("rule")
+        return
+
     # Offer to apply immediately
     offer_apply_rules(root)
 
@@ -996,7 +1063,8 @@ def _network_remove(args: argparse.Namespace):
     """Remove a network rule."""
     render_banner()
     root = find_project_root()
-    rules = load_network_rules(root)
+    cfg = load_network_config(root)
+    rules = cfg.rules
 
     host_input = getattr(args, "host", None)
     if not host_input:
@@ -1014,6 +1082,10 @@ def _network_remove(args: argparse.Namespace):
     save_network_rules(root, rules)
     console.print(f"[green]✓[/green] Removed [cyan]{host}:{port}[/cyan]")
 
+    if cfg.allow_all_egress:
+        _print_allow_all_warning_note("removal")
+        return
+
     # Offer to apply immediately
     offer_apply_rules(root)
 
@@ -1022,32 +1094,46 @@ def _network_apply(args: argparse.Namespace):
     """Apply current network rules to Snowflake."""
     render_banner()
     root = find_project_root()
-    rules = load_network_rules(root)
+    cfg = load_network_config(root)
 
-    if not rules:
-        console.print("[yellow]No network rules to apply.[/yellow]")
-        console.print("Add rules with [cyan]snowclaw network add <host>[/cyan] first.")
-        return
+    if cfg.allow_all_egress:
+        _print_allow_all_banner()
+        console.print()
+        approved = inquirer.confirm(
+            message="Apply allow-all egress to Snowflake?",
+            default=True,
+        ).execute()
+        if not approved:
+            console.print("[dim]Aborted.[/dim]")
+            return
+    else:
+        if not cfg.rules:
+            console.print("[yellow]No network rules to apply.[/yellow]")
+            console.print("Add rules with [cyan]snowclaw network add <host>[/cyan] first.")
+            return
 
-    console.print("[bold]Current network rules:[/bold]")
-    console.print(format_rules_table(rules))
-    console.print()
+        console.print("[bold]Current network rules:[/bold]")
+        console.print(format_rules_table(cfg.rules))
+        console.print()
 
-    approved = inquirer.confirm(
-        message=f"Apply {len(rules)} rule(s) to Snowflake?",
-        default=True,
-    ).execute()
+        approved = inquirer.confirm(
+            message=f"Apply {len(cfg.rules)} rule(s) to Snowflake?",
+            default=True,
+        ).execute()
 
-    if not approved:
-        console.print("[dim]Aborted.[/dim]")
-        return
+        if not approved:
+            console.print("[dim]Aborted.[/dim]")
+            return
 
     ctx = load_snowflake_context(root)
     if not ctx["account"] or not ctx["token"]:
         console.print("[red]Missing Snowflake credentials in .env.[/red]")
         sys.exit(1)
 
-    success = apply_network_rules(ctx["account"], ctx["token"], ctx["names"], rules)
+    success = apply_network_rules(
+        ctx["account"], ctx["token"], ctx["names"], cfg.rules,
+        allow_all=cfg.allow_all_egress,
+    )
     if success:
         console.print()
         console.print("[green]Network rules applied to Snowflake.[/green]")
@@ -1061,8 +1147,17 @@ def _network_detect(args: argparse.Namespace):
     """Auto-detect required network rules from project config."""
     render_banner()
     root = find_project_root()
+    cfg = load_network_config(root)
 
-    current = load_network_rules(root)
+    if cfg.allow_all_egress:
+        _print_allow_all_banner()
+        console.print(
+            "[dim]Detection is skipped in allow-all mode. Run "
+            "[cyan]snowclaw network restrict[/cyan] to return to the allowlist.[/dim]"
+        )
+        return
+
+    current = cfg.rules
     detected = detect_required_rules(root)
 
     if not detected:
@@ -1106,6 +1201,108 @@ def _network_detect(args: argparse.Namespace):
         offer_apply_rules(root)
     else:
         console.print("[dim]Rules not saved.[/dim]")
+
+
+def _network_allow_all(args: argparse.Namespace):
+    """Enable allow-all egress mode (all outbound on ports 443 and 80)."""
+    from snowclaw.network import print_allow_all_warning
+
+    render_banner()
+    root = find_project_root()
+    cfg = load_network_config(root)
+
+    if cfg.allow_all_egress:
+        _print_allow_all_banner()
+        console.print("[dim]Already enabled. Nothing to do.[/dim]")
+        return
+
+    print_allow_all_warning()
+    console.print()
+    confirm_enable = inquirer.confirm(
+        message="Enable allow-all egress?",
+        default=False,
+    ).execute()
+    if not confirm_enable:
+        console.print("[dim]Aborted. Allowlist mode retained.[/dim]")
+        return
+
+    cfg.allow_all_egress = True
+    save_network_config(root, cfg)
+    console.print("[bold red]Allow-all egress enabled.[/bold red]")
+
+    apply_now = inquirer.confirm(
+        message="Apply to Snowflake now?",
+        default=True,
+    ).execute()
+    if not apply_now:
+        console.print(
+            "[dim]Run [cyan]snowclaw network apply[/cyan] when you're ready.[/dim]"
+        )
+        return
+
+    ctx = load_snowflake_context(root)
+    if not ctx["account"] or not ctx["token"]:
+        console.print("[red]Missing Snowflake credentials in .env.[/red]")
+        return
+    success = apply_network_rules(
+        ctx["account"], ctx["token"], ctx["names"], cfg.rules, allow_all=True,
+    )
+    if success:
+        console.print("[green]Applied to Snowflake.[/green]")
+    else:
+        console.print(
+            "[red]Failed to apply. Retry with [cyan]snowclaw network apply[/cyan].[/red]"
+        )
+
+
+def _network_restrict(args: argparse.Namespace):
+    """Disable allow-all mode and re-apply the saved allowlist."""
+    render_banner()
+    root = find_project_root()
+    cfg = load_network_config(root)
+
+    if not cfg.allow_all_egress:
+        console.print("[dim]Already in allowlist mode. Nothing to do.[/dim]")
+        return
+
+    cfg.allow_all_egress = False
+    save_network_config(root, cfg)
+    console.print("[green]Allowlist mode restored.[/green]")
+
+    if not cfg.rules:
+        console.print(
+            "[yellow]No rules saved.[/yellow] Run [cyan]snowclaw network detect[/cyan] "
+            "to populate the allowlist from your config."
+        )
+        return
+
+    console.print("[bold]Saved rules:[/bold]")
+    console.print(format_rules_table(cfg.rules))
+    console.print()
+
+    apply_now = inquirer.confirm(
+        message=f"Apply {len(cfg.rules)} rule(s) to Snowflake now?",
+        default=True,
+    ).execute()
+    if not apply_now:
+        console.print(
+            "[dim]Run [cyan]snowclaw network apply[/cyan] when you're ready.[/dim]"
+        )
+        return
+
+    ctx = load_snowflake_context(root)
+    if not ctx["account"] or not ctx["token"]:
+        console.print("[red]Missing Snowflake credentials in .env.[/red]")
+        return
+    success = apply_network_rules(
+        ctx["account"], ctx["token"], ctx["names"], cfg.rules, allow_all=False,
+    )
+    if success:
+        console.print("[green]Applied to Snowflake.[/green]")
+    else:
+        console.print(
+            "[red]Failed to apply. Retry with [cyan]snowclaw network apply[/cyan].[/red]"
+        )
 
 
 def cmd_status(args: argparse.Namespace):

--- a/snowclaw/network.py
+++ b/snowclaw/network.py
@@ -40,26 +40,70 @@ class NetworkRule:
 
 RULES_FILE = "network-rules.json"
 
+# Snowflake's documented "allow all outbound" pattern for MODE=EGRESS TYPE=HOST_PORT
+# rules. `0.0.0.0` is the catch-all host; only 443 and 80 are accepted as ports.
+# https://docs.snowflake.com/en/user-guide/network-rules
+ALLOW_ALL_VALUE_LIST: tuple[str, ...] = ("0.0.0.0:443", "0.0.0.0:80")
+
+
+@dataclass
+class NetworkRulesConfig:
+    """On-disk shape of ``.snowclaw/network-rules.json``.
+
+    ``rules`` is preserved even when ``allow_all_egress`` is True so toggling
+    back to restrict mode restores the user's prior allowlist.
+    """
+
+    allow_all_egress: bool = False
+    rules: list[NetworkRule] = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.rules is None:
+            self.rules = []
+
 
 def _rules_path(root: Path) -> Path:
     return root / ".snowclaw" / RULES_FILE
 
 
-def load_network_rules(root: Path) -> list[NetworkRule]:
-    """Load network rules from .snowclaw/network-rules.json."""
+def load_network_config(root: Path) -> NetworkRulesConfig:
+    """Load the full network rules config (mode + rules).
+
+    Tolerant of legacy files that only contain ``{"rules": [...]}`` — the
+    ``allow_all_egress`` flag defaults to False.
+    """
     path = _rules_path(root)
     if not path.exists():
-        return []
+        return NetworkRulesConfig()
     data = json.loads(path.read_text())
-    return [NetworkRule(**r) for r in data.get("rules", [])]
+    rules = [NetworkRule(**r) for r in data.get("rules", [])]
+    return NetworkRulesConfig(
+        allow_all_egress=bool(data.get("allow_all_egress", False)),
+        rules=rules,
+    )
+
+
+def save_network_config(root: Path, cfg: NetworkRulesConfig):
+    """Persist the full network rules config."""
+    path = _rules_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "allow_all_egress": cfg.allow_all_egress,
+        "rules": [asdict(r) for r in cfg.rules],
+    }
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def load_network_rules(root: Path) -> list[NetworkRule]:
+    """Back-compat shim: return just the rules list."""
+    return load_network_config(root).rules
 
 
 def save_network_rules(root: Path, rules: list[NetworkRule]):
-    """Save network rules to .snowclaw/network-rules.json."""
-    path = _rules_path(root)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    data = {"rules": [asdict(r) for r in rules]}
-    path.write_text(json.dumps(data, indent=2) + "\n")
+    """Back-compat shim: preserve ``allow_all_egress`` while updating rules."""
+    cfg = load_network_config(root)
+    cfg.rules = rules
+    save_network_config(root, cfg)
 
 
 # ---------------------------------------------------------------------------
@@ -360,25 +404,64 @@ def print_diff(added: list[NetworkRule], removed: list[NetworkRule]):
         )
 
 
+def print_allow_all_warning():
+    """Print the red warning shown before enabling allow-all egress mode."""
+    from rich.panel import Panel
+
+    body = (
+        "[bold]Enabling allow-all egress removes SPCS's default outbound hardening.[/bold]\n\n"
+        "While this mode is active the agent can reach any host on ports 443 and 80,\n"
+        "including internal corporate URLs, arbitrary third-party APIs, and\n"
+        "unreviewed destinations. The Cortex proxy's secret masking still runs, but\n"
+        "masking is not a substitute for an egress allowlist — a compromised or\n"
+        "unintentionally malicious plugin / tool can exfiltrate unmasked data.\n\n"
+        "Recommended only for: internal development, exploration, and deployments\n"
+        "where you have no compliance obligations. Do not enable in production for\n"
+        "regulated workloads."
+    )
+    console.print(
+        Panel(
+            body,
+            title="[bold red]⚠  Allow-all egress[/bold red]",
+            border_style="red",
+            expand=False,
+        )
+    )
+
+
 # ---------------------------------------------------------------------------
 # SQL generation
 # ---------------------------------------------------------------------------
 
 
-def build_network_rule_sql(names: dict, rules: list[NetworkRule]) -> list[str]:
+def _format_value_list(items: list[str] | tuple[str, ...]) -> str:
+    return ", ".join(f"'{v}'" for v in items)
+
+
+def build_network_rule_sql(
+    names: dict,
+    rules: list[NetworkRule],
+    allow_all: bool = False,
+) -> list[str]:
     """Build standalone SQL statements for the reference ``network-rules.sql`` file.
 
     Uses CREATE OR REPLACE so the file can be applied to a fresh schema in one
     shot. The runtime apply path (``apply_network_rules``) prefers ALTER for
     steady-state updates so the NR object identity is preserved and the EAI
     binding stays valid without an SPCS service restart.
+
+    When ``allow_all`` is True, the rule's VALUE_LIST is
+    ``('0.0.0.0:443', '0.0.0.0:80')`` — Snowflake's documented allow-all
+    pattern — and the ``rules`` argument is ignored.
     """
-    if not rules:
+    if allow_all:
+        value_list = _format_value_list(ALLOW_ALL_VALUE_LIST)
+    elif rules:
+        value_list = _format_value_list([r.host_port for r in rules])
+    else:
         return []
 
     s = names["schema"]
-    value_list = ", ".join(f"'{r.host_port}'" for r in rules)
-
     return [
         (
             f"CREATE OR REPLACE NETWORK RULE {s}.{names['egress_rule']} "
@@ -412,7 +495,11 @@ def _external_access_integration_exists(account: str, pat: str, name: str) -> bo
 
 
 def apply_network_rules(
-    account: str, pat: str, names: dict, rules: list[NetworkRule]
+    account: str,
+    pat: str,
+    names: dict,
+    rules: list[NetworkRule],
+    allow_all: bool = False,
 ) -> bool:
     """Apply network rules to Snowflake via REST API.
 
@@ -421,16 +508,22 @@ def apply_network_rules(
     service picks up the new host list without a restart. The NR and EAI are
     only issued as ``CREATE`` when they don't already exist.
 
+    When ``allow_all`` is True, the applied VALUE_LIST is
+    ``('0.0.0.0:443', '0.0.0.0:80')`` regardless of ``rules``.
+
     Returns True if successful, False otherwise.
     """
-    if not rules:
+    if allow_all:
+        value_list = _format_value_list(ALLOW_ALL_VALUE_LIST)
+    elif rules:
+        value_list = _format_value_list([r.host_port for r in rules])
+    else:
         console.print("  [dim]No network rules to apply.[/dim]")
         return True
 
     s = names["schema"]
     egress = names["egress_rule"]
     eai = names["external_access"]
-    value_list = ", ".join(f"'{r.host_port}'" for r in rules)
 
     try:
         nr_exists = _network_rule_exists(account, pat, s, egress)
@@ -489,11 +582,21 @@ def prompt_and_apply_rules(
 ) -> list[NetworkRule]:
     """Detect required rules, show diff, prompt for approval, and apply.
 
-    Returns the final approved rule list.
+    Returns the final approved rule list. In allow-all mode this short-circuits
+    the diff flow and just ensures the NR is in allow-all state.
     """
     from InquirerPy import inquirer
 
-    current = load_network_rules(root)
+    cfg = load_network_config(root)
+    current = cfg.rules
+    if cfg.allow_all_egress:
+        console.print(
+            "[bold red]Egress mode: ALLOW ALL[/bold red] "
+            "[dim](unrestricted — 0.0.0.0:443, 0.0.0.0:80)[/dim]"
+        )
+        apply_network_rules(account, pat, names, current, allow_all=True)
+        return current
+
     if detected is None:
         detected = detect_required_rules(root)
 
@@ -590,8 +693,11 @@ def offer_apply_rules(root: Path):
         if not ctx["account"] or not ctx["token"]:
             console.print("[red]Missing Snowflake credentials in .env.[/red]")
             return
-        rules = load_network_rules(root)
-        success = apply_network_rules(ctx["account"], ctx["token"], ctx["names"], rules)
+        cfg = load_network_config(root)
+        success = apply_network_rules(
+            ctx["account"], ctx["token"], ctx["names"], cfg.rules,
+            allow_all=cfg.allow_all_egress,
+        )
         if success:
             console.print("[green]Network rules applied to Snowflake.[/green]")
         else:

--- a/snowclaw/scaffold.py
+++ b/snowclaw/scaffold.py
@@ -15,6 +15,7 @@ from snowclaw.network import (
     build_network_rule_sql,
     get_channel_secrets,
     get_env_secrets,
+    load_network_config,
     load_network_rules,
 )
 from snowclaw.utils import console, get_templates_dir, read_marker, sf_names, sf_proxy_names
@@ -319,13 +320,21 @@ def assemble_build_context(root: Path) -> Path:
 
     # Generate network-rules.sql from saved rules
     names = sf_names(database, schema_name)
-    rules = load_network_rules(root)
-    if rules:
-        stmts = build_network_rule_sql(names, rules)
+    net_cfg = load_network_config(root)
+    if net_cfg.allow_all_egress or net_cfg.rules:
+        stmts = build_network_rule_sql(
+            names, net_cfg.rules, allow_all=net_cfg.allow_all_egress
+        )
         if stmts:
+            header_note = (
+                "-- MODE: ALLOW ALL (0.0.0.0:443, 0.0.0.0:80)\n"
+                if net_cfg.allow_all_egress
+                else ""
+            )
             header = (
                 "-- Network rules (generated from .snowclaw/network-rules.json)\n"
-                "-- Manage with: snowclaw network list|add|remove|apply|detect\n\n"
+                "-- Manage with: snowclaw network list|add|remove|apply|detect\n"
+                f"{header_note}\n"
             )
             (spcs_dir / "network-rules.sql").write_text(
                 header + ";\n\n".join(stmts) + ";\n"

--- a/tests/test_network_mode.py
+++ b/tests/test_network_mode.py
@@ -1,0 +1,111 @@
+"""Tests for allow-all egress mode in snowclaw.network."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from snowclaw.network import (
+    ALLOW_ALL_VALUE_LIST,
+    NetworkRule,
+    NetworkRulesConfig,
+    build_network_rule_sql,
+    load_network_config,
+    load_network_rules,
+    save_network_config,
+    save_network_rules,
+)
+
+
+NAMES = {
+    "schema": "DB.SCH",
+    "egress_rule": "foo_egress_rule",
+    "external_access": "foo_external_access",
+}
+
+
+@pytest.fixture
+def project_root(tmp_path: Path) -> Path:
+    (tmp_path / ".snowclaw").mkdir()
+    return tmp_path
+
+
+def test_allow_all_value_list_constant():
+    assert ALLOW_ALL_VALUE_LIST == ("0.0.0.0:443", "0.0.0.0:80")
+
+
+def test_build_sql_allowlist_mode():
+    rules = [NetworkRule("example.com", 443, "test")]
+    stmts = build_network_rule_sql(NAMES, rules)
+    assert len(stmts) == 2
+    assert "VALUE_LIST = ('example.com:443')" in stmts[0]
+    assert "CREATE OR REPLACE NETWORK RULE" in stmts[0]
+    assert "CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION" in stmts[1]
+
+
+def test_build_sql_allow_all_ignores_rules():
+    rules = [NetworkRule("example.com", 443, "ignored")]
+    stmts = build_network_rule_sql(NAMES, rules, allow_all=True)
+    assert len(stmts) == 2
+    assert "VALUE_LIST = ('0.0.0.0:443', '0.0.0.0:80')" in stmts[0]
+    assert "example.com" not in stmts[0]
+
+
+def test_build_sql_allow_all_with_empty_rules():
+    stmts = build_network_rule_sql(NAMES, [], allow_all=True)
+    assert len(stmts) == 2
+    assert "VALUE_LIST = ('0.0.0.0:443', '0.0.0.0:80')" in stmts[0]
+
+
+def test_build_sql_empty_rules_allowlist_mode_returns_empty():
+    assert build_network_rule_sql(NAMES, []) == []
+
+
+def test_load_network_config_legacy_file_defaults_to_allowlist(project_root: Path):
+    """A file without the allow_all_egress key (pre-feature shape) loads safely."""
+    legacy = {"rules": [{"host": "a.com", "port": 443, "reason": "legacy"}]}
+    (project_root / ".snowclaw" / "network-rules.json").write_text(json.dumps(legacy))
+
+    cfg = load_network_config(project_root)
+    assert cfg.allow_all_egress is False
+    assert cfg.rules == [NetworkRule("a.com", 443, "legacy")]
+
+
+def test_load_network_config_missing_file_returns_defaults(project_root: Path):
+    cfg = load_network_config(project_root)
+    assert cfg.allow_all_egress is False
+    assert cfg.rules == []
+
+
+def test_save_and_load_roundtrip_preserves_mode(project_root: Path):
+    cfg = NetworkRulesConfig(
+        allow_all_egress=True,
+        rules=[NetworkRule("a.com", 443, "r1"), NetworkRule("b.com", 443, "r2")],
+    )
+    save_network_config(project_root, cfg)
+
+    loaded = load_network_config(project_root)
+    assert loaded.allow_all_egress is True
+    assert loaded.rules == cfg.rules
+
+
+def test_save_network_rules_shim_preserves_allow_all_flag(project_root: Path):
+    """The back-compat save_network_rules shim must not clobber allow_all_egress."""
+    initial = NetworkRulesConfig(allow_all_egress=True, rules=[])
+    save_network_config(project_root, initial)
+
+    save_network_rules(project_root, [NetworkRule("new.com", 443, "added")])
+
+    cfg = load_network_config(project_root)
+    assert cfg.allow_all_egress is True
+    assert cfg.rules == [NetworkRule("new.com", 443, "added")]
+
+
+def test_load_network_rules_shim_returns_rules_list(project_root: Path):
+    save_network_config(
+        project_root,
+        NetworkRulesConfig(allow_all_egress=True, rules=[NetworkRule("a.com", 443, "")]),
+    )
+    assert load_network_rules(project_root) == [NetworkRule("a.com", 443, "")]


### PR DESCRIPTION
> Stacked on top of #80. Review/merge that PR first — after it lands, change this PR's base to `main`.

## Summary
Adds an opt-in "allow all" egress mode behind a red warning panel + explicit `default=False` confirm. When enabled, the SPCS `NETWORK RULE`'s `VALUE_LIST` is set to Snowflake's [documented](https://docs.snowflake.com/en/user-guide/network-rules) catch-all pattern `('0.0.0.0:443', '0.0.0.0:80')` (ports 443 and 80 only — Snowflake limitation). The saved allowlist is preserved so `snowclaw network restrict` reverts in a single command.

### User-visible changes
- `snowclaw network allow-all` — red warning panel, confirm(default=False), then flip mode and optionally apply to Snowflake.
- `snowclaw network restrict` — disable allow-all, re-apply saved allowlist.
- `snowclaw setup` — after the existing allowlist approval, asks once: *"Skip the allowlist and permit all outbound traffic instead? (not recommended)"* defaulting to **No**. If Yes, shows the red warning + a second confirm.
- `snowclaw network list` — shows a red `Egress mode: ALLOW ALL` banner when active, still lists the saved allowlist underneath (dimmed) so users see what will be restored.
- `snowclaw network add` / `remove` while allow-all is active — persist the change and print a yellow note that it won't take effect until `snowclaw network restrict`.
- `snowclaw deploy` — in allow-all mode skips the detect/diff flow and just idempotently ensures the allow-all NR is applied (via the ALTER path from #80, so no service restart).

### Storage
`.snowclaw/network-rules.json` now has shape `{ "allow_all_egress": bool, "rules": [...] }`. Legacy files without the flag load with `allow_all_egress=False`. `load_network_rules` / `save_network_rules` are thin back-compat shims over `load_network_config` / `save_network_config`; the save shim preserves the mode flag so older call sites don't silently disable allow-all.

### Reference SQL
`.snowclaw/build/spcs/network-rules.sql` reflects the active mode — allow-all adds a `-- MODE: ALLOW ALL` header line and the catch-all VALUE_LIST.

## Test plan
- [x] `pytest tests/` — 150 passed (10 new in `test_network_mode.py` covering constant, SQL shape for both modes, legacy-file load, round-trip, and the back-compat shim preserving the mode flag).
- [x] `snowclaw network --help` — both new subcommands listed.
- [ ] Manual: on an existing deployment, `snowclaw network allow-all`, confirm red warning + `default=False` confirm, confirm `ALTER NETWORK RULE ... SET VALUE_LIST = ('0.0.0.0:443', '0.0.0.0:80')` runs without a service restart, verify arbitrary-host `curl` from the agent container succeeds.
- [ ] Manual: `snowclaw network add foo.example.com` while allow-all is on — yellow note prints, rule is persisted but not applied.
- [ ] Manual: `snowclaw network restrict` — saved allowlist is re-applied via `ALTER`; arbitrary-host `curl` now fails.
- [ ] Manual: fresh `snowclaw setup`, decline the allow-all prompt, confirm safe default.
- [ ] Manual: `snowclaw build` in both modes, confirm `.snowclaw/build/spcs/network-rules.sql` matches.

## Out of scope
- Ports other than 443 / 80 (Snowflake's `0.0.0.0` limitation). Users needing e.g. port 22 add a specific host rule.
- A "block all" / EAI disable kill switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)