### PR TITLE
Drop agents.defaults.params from generated openclaw.json

### DIFF
--- a/snowclaw/config.py
+++ b/snowclaw/config.py
@@ -301,13 +301,6 @@ def write_openclaw_config(root: Path, settings: dict):
         "channels": {},
         "agents": {"defaults": {
             "model": f"{provider_for_model(default_model_id)}/{default_model_id}",
-            "params": {
-                # Forward-compatible: OpenClaw injects ephemeral cache_control on system + trailing
-                # user blocks. The "long" knob upgrades to 1h TTL only against api.anthropic.com /
-                # Vertex hosts (OpenClaw gates this on hostname); against our proxy it still emits
-                # 5m ephemeral, which is the v1 target. 1h upgrade is a future proxy enhancement.
-                "cacheRetention": "long",
-            },
         }},
     }
 


### PR DESCRIPTION
## Summary
- Remove the `agents.defaults.params.cacheRetention = "long"` block from configs written by `write_openclaw_config`.
- The setting was a no-op against the Cortex proxy URL (OpenClaw only upgrades to 1h ephemeral TTL for `api.anthropic.com` / Vertex hosts), so new projects no longer ship it.

## Test plan
- [ ] Run `snowclaw setup` in a fresh directory and confirm the generated `openclaw.json` has no `agents.defaults.params` key.
- [ ] Existing deployments are unaffected (migration path untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)