### PR TITLE
feat: add --tail flag to snowclaw logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ Variables listed in `SNOWCLAW_MASK_VARS` (a comma-separated list in `.env`) are 
 | `snowclaw suspend` | Suspend the SPCS service and compute pool |
 | `snowclaw resume` | Resume the SPCS compute pool and service |
 | `snowclaw restart` | Restart the service to pick up config changes |
-| `snowclaw logs` | Show container logs from the SPCS service |
+| `snowclaw logs` | Show container logs from the SPCS service (add `-f`/`--tail` to follow) |
 | `snowclaw update` | Update the OpenClaw base image version |
 | `snowclaw push` | Push skills and openclaw.json (and secrets) to SPCS stage |
 | `snowclaw push --secrets` | Update only Snowflake secrets and connections.toml (skip file sync) |

--- a/snowclaw/cli.py
+++ b/snowclaw/cli.py
@@ -56,6 +56,8 @@ def build_parser() -> argparse.ArgumentParser:
     logs_parser.add_argument("-p", "--proxy", action="store_true", help="Show proxy container logs instead of openclaw")
     logs_parser.add_argument("--container", default="openclaw", help="Container name (default: openclaw)")
     logs_parser.add_argument("--instance", default="0", help="Instance ID (default: 0)")
+    logs_parser.add_argument("-f", "--tail", action="store_true", help="Follow the logs (poll for new lines until Ctrl+C)")
+    logs_parser.add_argument("--interval", type=float, default=2.0, help="Poll interval in seconds when --tail is set (default: 2.0)")
 
     pull_parser = sub.add_parser(
         "pull",

--- a/snowclaw/commands.py
+++ b/snowclaw/commands.py
@@ -2328,36 +2328,88 @@ def cmd_logs(args: argparse.Namespace):
     num_lines = getattr(args, "lines", 100)
     container = "cortex-proxy" if getattr(args, "proxy", False) else getattr(args, "container", "openclaw")
     instance_id = getattr(args, "instance", "0")
+    follow = getattr(args, "tail", False)
+    interval = max(0.5, float(getattr(args, "interval", 2.0)))
 
     fqn_service = f"{fqn_schema}.{service_name}"
-    sql = (
-        f"CALL SYSTEM$GET_SERVICE_LOGS("
-        f"'{fqn_service}', '{instance_id}', '{container}', {num_lines})"
-    )
 
-    console.print(
-        f"[bold]Fetching logs:[/bold] {service_name} "
-        f"[dim](container={container}, instance={instance_id}, lines={num_lines})[/dim]"
-    )
-    console.print()
-
-    try:
+    def _fetch(lines: int) -> str:
+        sql = (
+            f"CALL SYSTEM$GET_SERVICE_LOGS("
+            f"'{fqn_service}', '{instance_id}', '{container}', {lines})"
+        )
         data = snowflake_rest_execute(
             account, token, sql,
             database=db, schema=schema_name, warehouse=warehouse,
         )
         rows = data.get("data", [])
-        if rows and rows[0]:
-            log_text = rows[0][0]
+        if rows and rows[0] and rows[0][0]:
+            return rows[0][0]
+        return ""
+
+    header_extra = f", follow=True, interval={interval}s" if follow else ""
+    console.print(
+        f"[bold]Fetching logs:[/bold] {service_name} "
+        f"[dim](container={container}, instance={instance_id}, lines={num_lines}{header_extra})[/dim]"
+    )
+    console.print()
+
+    if not follow:
+        try:
+            log_text = _fetch(num_lines)
             if log_text:
                 console.print(log_text)
             else:
                 console.print("[dim]No log output returned.[/dim]")
-        else:
-            console.print("[dim]No log output returned.[/dim]")
-    except requests.HTTPError as e:
-        console.print(f"[red]Failed to fetch logs:[/red] {e}")
-        sys.exit(1)
+        except requests.HTTPError as e:
+            console.print(f"[red]Failed to fetch logs:[/red] {e}")
+            sys.exit(1)
+        return
+
+    # Follow mode: poll SYSTEM$GET_SERVICE_LOGS, dedupe against the last printed
+    # line. Snowflake returns the most recent N lines per call, so if log volume
+    # exceeds `poll_lines` per `interval` we'll miss output — bump --lines or
+    # shrink --interval if that warning fires.
+    poll_lines = max(num_lines, 200)
+    last_line: str | None = None
+    console.print("[dim]Tailing logs (Ctrl+C to stop)...[/dim]")
+    try:
+        while True:
+            try:
+                log_text = _fetch(poll_lines)
+            except requests.HTTPError as e:
+                console.print(f"[yellow]Transient fetch error:[/yellow] {e}")
+                time.sleep(interval)
+                continue
+
+            if log_text:
+                lines = log_text.splitlines()
+                if last_line is None:
+                    new_lines = lines[-num_lines:]
+                else:
+                    idx = None
+                    for i in range(len(lines) - 1, -1, -1):
+                        if lines[i] == last_line:
+                            idx = i
+                            break
+                    if idx is None:
+                        console.print(
+                            "[yellow]Log buffer rolled past last seen line; "
+                            "some lines may have been missed. "
+                            "Consider raising --lines or lowering --interval.[/yellow]"
+                        )
+                        new_lines = lines
+                    else:
+                        new_lines = lines[idx + 1:]
+                for line in new_lines:
+                    console.print(line)
+                if new_lines:
+                    last_line = new_lines[-1]
+
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        console.print()
+        console.print("[dim]Stopped tailing.[/dim]")
 
 
 def cmd_upgrade(args: argparse.Namespace):


### PR DESCRIPTION
## Summary
- Adds `-f` / `--tail` to `snowclaw logs` so you can follow container output live during a deploy instead of running the command repeatedly.
- Adds `--interval <seconds>` (default `2.0`) for the poll cadence.
- The default (no flag) behaviour of `snowclaw logs` is unchanged.

### How it works
`SYSTEM$GET_SERVICE_LOGS` is a one-shot SQL UDF, so follow mode polls it every `--interval` seconds. Each poll requests `max(--lines, 200)` lines and prints whatever appears strictly after the last line already shown. If the log window rolls past the last seen line between polls, the CLI prints a yellow warning suggesting the user raise `--lines` or lower `--interval` rather than silently dropping output. `Ctrl+C` cleanly exits with a `Stopped tailing.` message.

### Motivation
Troubleshooting a deploy with the existing one-shot `snowclaw logs` means re-running the command in a loop and visually diffing output, which is easy to misread. `tail -f` semantics are the natural fit while watching the openclaw container come up.

## Test plan
- [ ] `snowclaw logs` (no flag) — unchanged: prints last 100 lines once and exits.
- [ ] `snowclaw logs -f` — prints recent lines, then continues to print new lines as the service produces them; exits cleanly on Ctrl+C.
- [ ] `snowclaw logs --tail --interval 5` — same as above, polling every 5s.
- [ ] `snowclaw logs -f -p` — follow the cortex-proxy container.
- [ ] Force a fast log burst (or use a small `-n` like `-n 5`) to verify the "Log buffer rolled past last seen line" warning appears and we resync without crashing.
- [ ] `snowclaw logs --help` — new flags appear in usage output.